### PR TITLE
 #157879438 Document API endpoints using Swagger

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Hello-Books is a simple application that helps manage a library and its processe
 borrow or return a book.
 
 ## API Documentation
-Visit [here](https://hello-books-v2.herokuapp.com/docs/#/) for a detailed documentation on the API endpoints used in the application
+Visit [here](https://hello-books-v2.herokuapp.com/api/v1/docs/#/) for a detailed documentation on the API endpoints used in the application
 
 ## Hosting
 * The API is hosted on https://hello-books-v2.herokuapp.com/api/v1/

--- a/package-lock.json
+++ b/package-lock.json
@@ -13293,6 +13293,11 @@
         }
       }
     },
+    "swagger-ui-express": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-3.0.10.tgz",
+      "integrity": "sha1-xysyEHpXpHkT87RgA+j9Yqc3jqI="
+    },
     "symbol-observable": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -127,6 +127,7 @@
     "sinon": "^4.5.0",
     "superagent": "^3.8.3",
     "supertest": "^3.0.0",
+    "swagger-ui-express": "^3.0.10",
     "url-loader": "^1.0.1",
     "webpack-dev-middleware": "^3.0.1",
     "webpack-hot-middleware": "^2.21.2"

--- a/server/controllers/books.js
+++ b/server/controllers/books.js
@@ -119,7 +119,7 @@ export default class Book {
       },
     }).then((vote) => {
       if (vote && vote.voteType === voteType) {
-        return res.status(403).json({
+        return res.status(409).json({
           message: 'Unsuccessful',
           error: `You have already ${voteType}d this book`,
         });
@@ -183,7 +183,7 @@ export default class Book {
                 });
             });
         }
-        return res.status(403).json({
+        return res.status(409).json({
           message: 'Unsuccessful',
           error: 'Already favorited book',
         });
@@ -239,7 +239,7 @@ export default class Book {
                     reviewedBook,
                   }));
             }
-            return res.status(403).json({
+            return res.status(409).json({
               message: 'Unsuccessful',
               error: 'Your review has already been created',
             });

--- a/server/controllers/users.js
+++ b/server/controllers/users.js
@@ -186,7 +186,7 @@ export default class Users {
                       request,
                     }));
                 }
-                return res.status(403).json({
+                return res.status(409).json({
                   message: 'Unsuccessful',
                   error: 'Already sent request',
                 });
@@ -252,7 +252,7 @@ export default class Users {
                   }));
                 });
             }
-            return res.status(403).json({
+            return res.status(409).json({
               message: 'Unsuccessful',
               error: 'Your request has already been sent',
             });

--- a/server/helpers/Helper.js
+++ b/server/helpers/Helper.js
@@ -37,7 +37,7 @@ export default class Helper {
     const setup = {};
 
     setup.page = req.query.page && req.query.page > 0 ? req.query.page : 1;
-    setup.limit = req.query.limit && req.query.limit > 0 ? req.query.limit : 9;
+    setup.limit = req.query.limit && req.query.limit > 0 ? req.query.limit : 8;
     setup.offset = setup.limit * (setup.page - 1);
 
     return setup;

--- a/server/index.js
+++ b/server/index.js
@@ -1,16 +1,21 @@
 // import necessary modules
 import express from 'express';
 import bodyParser from 'body-parser';
+import swaggerUi from 'swagger-ui-express';
 import books from './routes/books';
 import users from './routes/users';
 import index from './routes/index';
-
+import swaggerDoc from '../swagger.json';
 // Create an express instance
 const app = express();
 
 // Set up middleware
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: false }));
+
+// Set up swagger-ui-express to serve API docs
+app.use('/api/v1/docs', swaggerUi.serve, swaggerUi.setup(swaggerDoc));
+
 
 // Specify route handlers
 app.use('/api/v1', index);

--- a/server/middlewares/verifyToken.js
+++ b/server/middlewares/verifyToken.js
@@ -17,7 +17,7 @@ const jwt = jsonwebtoken;
 const verifyToken = (req, res, next) => {
   // Get token from header
   if (!req.headers.authorization || req.headers.authorization === undefined) {
-    return res.status(403).send({
+    return res.status(401).send({
       message: 'Unsuccessful',
       error: 'No token provided',
     });
@@ -28,9 +28,11 @@ const verifyToken = (req, res, next) => {
   // Decode token
   jwt.verify(token, process.env.JWT_SECRET, (error, decoded) => {
     if (error) {
+      const errorMessage = error.name === 'TokenExpiredError' ?
+        'Session expired. Login to continue' : 'Failed to authenticate token';
       res.status(401).send({
         message: 'Unsuccessful',
-        error: 'Failed to authenticate token',
+        error: errorMessage,
       });
     }
     req.decoded = decoded;

--- a/server/tests/controllers/books.tests.js
+++ b/server/tests/controllers/books.tests.js
@@ -103,7 +103,7 @@ describe('Books Controller', () => {
         .send(testData.book)
         .end((err, res) => {
           expect(res.body.message).to.deep.equal('Unsuccessful');
-          expect(res.status).to.equal(403);
+          expect(res.status).to.equal(401);
           expect(res.body.error).to.deep.equal('No token provided');
           done();
         });
@@ -207,12 +207,12 @@ describe('Books Controller', () => {
           done();
         });
     });
-    it('should throw 403 error if no token is provided', (done) => {
+    it('should throw 401 error if no token is provided', (done) => {
       request(app)
         .post('/api/v1/books/1/review')
         .send({ review: 'An amazing read. I loved it!!!' })
         .end((err, res) => {
-          expect(res.status).to.equal(403);
+          expect(res.status).to.equal(401);
           expect(res.body.message).to.equal('Unsuccessful');
           expect(res.body.error).to.equal('No token provided');
           expect(res.body).to.not.have.property('reviewedBook');
@@ -243,13 +243,13 @@ describe('Books Controller', () => {
           done();
         });
     });
-    it('should return 403 error if review already exists', (done) => {
+    it('should return 409 error if review already exists', (done) => {
       request(app)
         .post('/api/v1/books/1/review')
         .set('Authorization', `Token ${userToken}`)
         .send({ review: 'An amazing read. I loved it!!!' })
         .end((err, res) => {
-          expect(res.status).to.equal(403);
+          expect(res.status).to.equal(409);
           expect(res.body.message).to.equal('Unsuccessful');
           expect(res.body.error).to.equal('Your review has already been created');
           done();
@@ -322,11 +322,11 @@ describe('Books Controller', () => {
   });
 
   describe('POST /api/v1/books/1/favorite', () => {
-    it('should throw 403 error for an unauthenticated user', (done) => {
+    it('should throw 401 error for an unauthenticated user', (done) => {
       request(app)
         .post('/api/v1/books/1/favorite')
         .end((err, res) => {
-          expect(res.status).to.equal(403);
+          expect(res.status).to.equal(401);
           expect(res.body.message).to.equal('Unsuccessful');
           expect(res.body.error).to.equal('No token provided');
           done();
@@ -370,12 +370,12 @@ describe('Books Controller', () => {
           done();
         });
     });
-    it('should return 403 error if book is already in user\'s favorites', (done) => {
+    it('should return 409 error if book is already in user\'s favorites', (done) => {
       request(app)
         .post('/api/v1/books/1/favorite')
         .set('Authorization', `Token ${userToken}`)
         .end((err, res) => {
-          expect(res.status).to.equal(403);
+          expect(res.status).to.equal(409);
           expect(res.body.message).to.equal('Unsuccessful');
           expect(res.body.error).to.equal('Already favorited book');
           expect(res.body).to.have.not.have.property('favorite');
@@ -385,11 +385,11 @@ describe('Books Controller', () => {
   });
 
   describe('POST /api/v1/books/:bookId/downvote', () => {
-    it('should throw 403 error if no token is provided', (done) => {
+    it('should throw 401 error if no token is provided', (done) => {
       request(app)
         .post('/api/v1/books/1/downvote')
         .end((err, res) => {
-          expect(res.status).to.equal(403);
+          expect(res.status).to.equal(401);
           expect(res.body.message).to.deep.equal('Unsuccessful');
           expect(res.body.error).to.deep.equal('No token provided');
           expect(res.body).to.not.have.property('vote');
@@ -420,12 +420,12 @@ describe('Books Controller', () => {
           done();
         });
     });
-    it('should throw 403 error if user has downvoted book before', (done) => {
+    it('should throw 409 error if user has downvoted book before', (done) => {
       request(app)
         .post('/api/v1/books/1/downvote')
         .set('Authorization', `Token ${userToken}`)
         .end((err, res) => {
-          expect(res.status).to.equal(403);
+          expect(res.status).to.equal(409);
           expect(res.body.message).to.deep.equal('Unsuccessful');
           expect(res.body.error).to.deep.equal('You have already downvoted this book');
           done();
@@ -445,11 +445,11 @@ describe('Books Controller', () => {
   });
 
   describe('POST /api/v1/books/:bookId/upvote', () => {
-    it('should throw 403 error if no token is provided', (done) => {
+    it('should throw 401 error if no token is provided', (done) => {
       request(app)
         .post('/api/v1/books/1/upvote')
         .end((err, res) => {
-          expect(res.status).to.equal(403);
+          expect(res.status).to.equal(401);
           expect(res.body.message).to.deep.equal('Unsuccessful');
           expect(res.body.error).to.deep.equal('No token provided');
           expect(res.body).to.not.have.property('vote');
@@ -480,12 +480,12 @@ describe('Books Controller', () => {
           done();
         });
     });
-    it('should throw 403 error if user has upvoted book before', (done) => {
+    it('should throw 409 error if user has upvoted book before', (done) => {
       request(app)
         .post('/api/v1/books/1/upvote')
         .set('Authorization', `Token ${userToken}`)
         .end((err, res) => {
-          expect(res.status).to.equal(403);
+          expect(res.status).to.equal(409);
           expect(res.body.message).to.deep.equal('Unsuccessful');
           expect(res.body.error).to.deep.equal('You have already upvoted this book');
           done();
@@ -613,11 +613,11 @@ describe('Books Controller', () => {
   });
 
   describe('DELETE /api/v1/books/:bookId', () => {
-    it('should throw 403 error if no token is provided', (done) => {
+    it('should throw 401 error if no token is provided', (done) => {
       request(app)
         .delete('/api/v1/books/88')
         .end((err, res) => {
-          expect(res.status).to.equal(403);
+          expect(res.status).to.equal(401);
           expect(res.body.message).to.equal('Unsuccessful');
           expect(res.body.error).to.equal('No token provided');
           done();

--- a/server/tests/controllers/users.tests.js
+++ b/server/tests/controllers/users.tests.js
@@ -164,11 +164,11 @@ describe('Users Controller', () => {
           done();
         });
     });
-    it('should throw 403 error if no token is provided', (done) => {
+    it('should throw 401 error if no token is provided', (done) => {
       request(app)
         .get('/api/v1/users/2/favbooks')
         .end((err, res) => {
-          expect(res.status).to.equal(403);
+          expect(res.status).to.equal(401);
           expect(res.body.message).to.equal('Unsuccessful');
           expect(res.body).to.have.not.have.property('favorites');
           expect(res.body.error).to.equal('No token provided');
@@ -191,11 +191,11 @@ describe('Users Controller', () => {
   });
 
   describe('POST /api/v1/users/:userId/borrow/:bookId', () => {
-    it('should throw 403 error if no token is provided', (done) => {
+    it('should throw 401 error if no token is provided', (done) => {
       request(app)
         .post('/api/v1/users/2/borrow/94')
         .end((err, res) => {
-          expect(res.status).to.equal(403);
+          expect(res.status).to.equal(401);
           expect(res.body.message).to.equal('Unsuccessful');
           expect(res.body).to.have.not.have.property('request');
           expect(res.body.error).to.equal('No token provided');
@@ -219,7 +219,7 @@ describe('Users Controller', () => {
           done();
         });
     });
-    it('should throw 403 error if the request has already been sent', (done) => {
+    it('should throw 409 error if the request has already been sent', (done) => {
       request(app)
         .post('/api/v1/users/2/borrow/94')
         .set('Authorization', `Token ${userToken}`)
@@ -228,7 +228,7 @@ describe('Users Controller', () => {
           returnDate: '12/12/2018',
         })
         .end((err, res) => {
-          expect(res.status).to.equal(403);
+          expect(res.status).to.equal(409);
           expect(res.body.message).to.equal('Unsuccessful');
           expect(res.body).to.not.have.property('request');
           expect(res.body.error).to.equal('Already sent request');
@@ -297,11 +297,11 @@ describe('Users Controller', () => {
           done();
         });
     });
-    it('should throw 403 error if no token is provided', (done) => {
+    it('should throw 401 error if no token is provided', (done) => {
       request(app)
         .put('/api/v1/users/2/borrow/94')
         .end((err, res) => {
-          expect(res.status).to.equal(403);
+          expect(res.status).to.equal(401);
           expect(res.body.message).to.equal('Unsuccessful');
           expect(res.body).to.have.not.have.property('borrowRequest');
           expect(res.body.error).to.equal('No token provided');
@@ -403,11 +403,11 @@ describe('Users Controller', () => {
   });
 
   describe('POST /api/v1/users/:userId/return/94', () => {
-    it('should throw 403 error if no token is provided', (done) => {
+    it('should throw 401 error if no token is provided', (done) => {
       request(app)
         .post('/api/v1/users/2/return/94')
         .end((err, res) => {
-          expect(res.status).to.equal(403);
+          expect(res.status).to.equal(401);
           expect(res.body.message).to.equal('Unsuccessful');
           expect(res.body).to.have.not.have.property('returnRequest');
           expect(res.body.error).to.equal('No token provided');
@@ -455,12 +455,12 @@ describe('Users Controller', () => {
           done();
         });
     });
-    it('should throw 403 error if a user has already sent the request', (done) => {
+    it('should throw 409 error if a user has already sent the request', (done) => {
       request(app)
         .post('/api/v1/users/2/return/94')
         .set('Authorization', `Token ${userToken}`)
         .end((err, res) => {
-          expect(res.status).to.equal(403);
+          expect(res.status).to.equal(409);
           expect(res.body.message).to.equal('Unsuccessful');
           expect(res.body).to.not.have.property('returnRequest');
           expect(res.body.error).to.equal('Your request has already been sent');
@@ -495,11 +495,11 @@ describe('Users Controller', () => {
   });
 
   describe('PUT /api/v1/users/:userId/return/:bookId', () => {
-    it('should throw 403 error if no token is provided', (done) => {
+    it('should throw 401 error if no token is provided', (done) => {
       request(app)
         .put('/api/v1/users/2/return/94')
         .end((err, res) => {
-          expect(res.status).to.equal(403);
+          expect(res.status).to.equal(401);
           expect(res.body.message).to.equal('Unsuccessful');
           expect(res.body).to.have.not.have.property('returnRequest');
           expect(res.body.error).to.equal('No token provided');
@@ -586,11 +586,11 @@ describe('Users Controller', () => {
   });
 
   describe('GET /api/v1/borrowRequests', () => {
-    it('should throw 403 error if no token is provided', (done) => {
+    it('should throw 401 error if no token is provided', (done) => {
       request(app)
         .get('/api/v1/borrowRequests')
         .end((err, res) => {
-          expect(res.status).to.equal(403);
+          expect(res.status).to.equal(401);
           expect(res.body.message).to.equal('Unsuccessful');
           expect(res.body).to.have.not.have.property('requests');
           expect(res.body.error).to.equal('No token provided');
@@ -624,11 +624,11 @@ describe('Users Controller', () => {
   });
 
   describe('GET /api/v1/returnRequests', () => {
-    it('should throw 403 error if no token is provided', (done) => {
+    it('should throw 401 error if no token is provided', (done) => {
       request(app)
         .get('/api/v1/returnRequests')
         .end((err, res) => {
-          expect(res.status).to.equal(403);
+          expect(res.status).to.equal(401);
           expect(res.body.message).to.equal('Unsuccessful');
           expect(res.body).to.have.not.have.property('requests');
           expect(res.body.error).to.equal('No token provided');
@@ -662,11 +662,11 @@ describe('Users Controller', () => {
   });
 
   describe('GET /api/v1/users/:userId', () => {
-    it('should throw 403 error if no token is provided', (done) => {
+    it('should throw 401 error if no token is provided', (done) => {
       request(app)
         .get('/api/v1/users/2')
         .end((err, res) => {
-          expect(res.status).to.equal(403);
+          expect(res.status).to.equal(401);
           expect(res.body.message).to.equal('Unsuccessful');
           expect(res.body).to.have.not.have.property('user');
           expect(res.body.error).to.equal('No token provided');

--- a/server/tests/models/models.test.js
+++ b/server/tests/models/models.test.js
@@ -9,7 +9,7 @@ describe('MODEL TEST', () => {
         description: 'Horror book ever',
         author: 'Amarachukwu Agbo',
         quantity: 4,
-        imageUrl: 'https://res.cloudinary.com/amarachukwu/image.jpg',
+        imageURL: 'https://res.cloudinary.com/amarachukwu/image.jpg',
         subject: 'Horror',
       })
         .then((newBook) => {

--- a/swagger.json
+++ b/swagger.json
@@ -1,0 +1,5906 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0",
+    "title": "Hello-books API",
+    "description": "### Introduction\n API Documentation for the Hello-books API v1.0\n### Overview\nHello-Books is a simple application that helps manage a library and its processes like stocking, tracking and renting books. It is built with NodeJS/ExpressJS for the back-end and React, Redux and MaterializeCSS for the front-end.\n### Status Codes\n200 - A resource was retrieved successfully (e.g. Getting all books in the application)\n\n201 - A resource was created successfully (e.g. Adding a new book, Signing up a user)\n\n202 - Request has been sent and has a status of pending\n\n204 - Resource has been successfully deleted\n\n400 - An invalid request (e.g Submitting an invalid data type in the request)\n\n401 - Authentication failed, could arise from expired token or invalid credentials\n\n403 - Authorization failed. It could occur when a user tries to access privileged resources without admin token.\n\n404 - A resource was not found. It could occur when a user tries to get a book that does not exist.\n\n### Authorization\nPrefix assignrd token with `Bearer` when making a request to an authenticated endpoint."
+  },
+  "basePath": "/api/v1",
+  "securityDefinitions": {
+    "adminToken": {
+      "description": "JWT token assigned to an admin",
+      "type": "apiKey",
+      "name": "Authorization",
+      "in": "header"
+    },
+    "userToken": {
+      "description": "JWT token assigned to a user",
+      "type": "apiKey",
+      "name": "Authorization",
+      "in": "header"
+    }
+  },
+  "schemes": [
+    "http",
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/users/signup": {
+      "post": {
+        "description": "Endpoint for a user to register in the application",
+        "summary": "Users signup",
+        "operationId": "UsersSignupPost",
+        "tags": [
+          "Users"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "Body",
+            "in": "body",
+            "required": true,
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/UsersSignuprequest"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/UsersSignupresponse"
+            },
+            "examples": {
+              "application/json": {
+                "message": "Successful",
+                "user": {
+                  "id": 6,
+                  "firstName": "Amarachi",
+                  "role": "User"
+                },
+                "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6NiwiaWF0IjoxNTI5ODQ0MDE1LCJleHAiOjE1Mjk5MzA0MTV9.3easojr1WjPEjlg7_OHvFbb0i8LN_iwch8TBnEkhZ14"
+              }
+            }
+          },
+          "400": {
+            "description": "The request cannot be fulfilled due to bad syntax.",
+            "schema": {
+              "$ref": "#/definitions/UsersSignuperrorresponse"
+            },
+            "examples": {
+              "application/json": {
+                "message": "Unsuccessful",
+                "error": "ValidationError: child \"email\" fails because [\"email\" must be a valid email]"
+              }
+            }
+          },
+          "409": {
+            "description": "Indicates that the request could not be processed because of conflict in the request, such as an edit conflict.",
+            "schema": {
+              "$ref": "#/definitions/UsersSignuperrorresponse"
+            },
+            "examples": {
+              "application/json": {
+                "message": "Unsuccessful",
+                "error": "Email already exists. Input a different email"
+              }
+            }
+          }
+        },
+        "x-unitTests": [
+          {
+            "request": {
+              "method": "POST",
+              "uri": "/users/signup",
+              "headers": {
+                "Content-Type": "application/json"
+              },
+              "body": "{\"firstName\":\"Amarachi\",\"lastName\":\"Agbo\",\"email\":\"amarachukwu.agbo@andela.com\",\"password\":\"password\"}"
+            },
+            "expectedResponse": {
+              "x-allowExtraHeaders": true,
+              "x-bodyMatchMode": "RAW",
+              "x-arrayOrderedMatching": false,
+              "x-arrayCheckCount": false,
+              "x-matchResponseSchema": true,
+              "headers": {
+                "Connection": "keep-alive",
+                "Content-Length": "225",
+                "Content-Type": "application/json; charset=utf-8",
+                "Date": "Sun, 24 Jun 2018 12:40:15 GMT",
+                "ETag": "W/\"e1-cOtfItPk7lMYgmQTGODo27fs+Oo\"",
+                "X-Powered-By": "Express"
+              },
+              "body": "{\"message\":\"Successful\",\"user\":{\"id\":6,\"firstName\":\"Amarachi\",\"role\":\"User\"},\"token\":\"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6NiwiaWF0IjoxNTI5ODQ0MDE1LCJleHAiOjE1Mjk5MzA0MTV9.3easojr1WjPEjlg7_OHvFbb0i8LN_iwch8TBnEkhZ14\"}"
+            },
+            "x-testShouldPass": true,
+            "x-testEnabled": true,
+            "x-testName": "Users signup",
+            "x-testDescription": "Endpoint for a user to register in the application"
+          }
+        ],
+        "x-operation-settings": {
+          "CollectParameters": false,
+          "AllowDynamicQueryParameters": false,
+          "AllowDynamicFormParameters": false,
+          "IsMultiContentStreaming": false
+        }
+      }
+    },
+    "/users/login": {
+      "post": {
+        "description": "Endpoint for users to sign in into the application",
+        "summary": "Users Login",
+        "operationId": "UsersLoginPost",
+        "tags": [
+          "Users"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "Body",
+            "in": "body",
+            "required": true,
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/UsersLoginrequest"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/UsersLoginresponse"
+            },
+            "examples": {
+              "application/json": {
+                "message": "Successful",
+                "user": {
+                  "id": 6,
+                  "firstName": "Amarachi",
+                  "role": "User"
+                },
+                "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6NiwiaWF0IjoxNTI5ODQ0MjkxLCJleHAiOjE1Mjk5MzA2OTF9.btGtiVDBpMOC0FGaixOLqNC2JPEEMkvNo5qBub6PVG4"
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "$ref": "#/definitions/UsersLoginerrorresponse"
+            },
+            "examples": {
+              "application/json": {
+                "message": "Unsuccessful",
+                "error": "ValidationError: child \"email\" fails because [\"email\" must be a valid email]"
+              }
+            }
+          },
+          "401": {
+            "description": "Similar to 403 Forbidden, but specifically for use when authentication is possible but has failed or not yet been provided. The response must include a WWW-Authenticate header field containing a challenge applicable to the requested resource.",
+            "schema": {
+              "$ref": "#/definitions/UsersLoginerrorresponse"
+            },
+            "examples": {
+              "application/json": {
+                "message": "Unsuccessful",
+                "error": "Password provided does not match the user"
+              }
+            }
+          },
+          "404": {
+            "description": "The requested resource could not be found but may be available again in the future. Subsequent requests by the client are permissible.",
+            "schema": {
+              "$ref": "#/definitions/UsersLoginerrorresponse"
+            },
+            "examples": {
+              "application/json": {
+                "message": "Unsuccessful",
+                "error": "User not found"
+              }
+            }
+          }
+        },
+        "x-unitTests": [
+          {
+            "request": {
+              "method": "POST",
+              "uri": "/users/login",
+              "headers": {
+                "Content-Type": "application/json"
+              },
+              "body": "{\"email\":\"amarachi@gmail.com\",\"password\":\"password\"}"
+            },
+            "expectedResponse": {
+              "x-allowExtraHeaders": true,
+              "x-bodyMatchMode": "RAW",
+              "x-arrayOrderedMatching": false,
+              "x-arrayCheckCount": false,
+              "x-matchResponseSchema": true,
+              "headers": {
+                "Connection": "keep-alive",
+                "Content-Length": "225",
+                "Content-Type": "application/json; charset=utf-8",
+                "Date": "Sun, 24 Jun 2018 12:44:51 GMT",
+                "ETag": "W/\"e1-/enhveNPs3aAX5fSQpAhCRFcsmk\"",
+                "X-Powered-By": "Express"
+              },
+              "body": "{\"message\":\"Successful\",\"user\":{\"id\":6,\"firstName\":\"Amarachi\",\"role\":\"User\"},\"token\":\"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6NiwiaWF0IjoxNTI5ODQ0MjkxLCJleHAiOjE1Mjk5MzA2OTF9.btGtiVDBpMOC0FGaixOLqNC2JPEEMkvNo5qBub6PVG4\"}"
+            },
+            "x-testShouldPass": true,
+            "x-testEnabled": true,
+            "x-testName": "Users Login",
+            "x-testDescription": "Endpoint for users to sign in into the application"
+          }
+        ],
+        "x-operation-settings": {
+          "CollectParameters": false,
+          "AllowDynamicQueryParameters": false,
+          "AllowDynamicFormParameters": false,
+          "IsMultiContentStreaming": false
+        }
+      }
+    },
+    "/users/{userId}/borrow/{bookId}": {
+      "post": {
+        "description": "Endpoint for an authenticated user to make a request to borrow a book. The request requires reason and returnDate, comments is optional",
+        "summary": "Make a request to borrow a book",
+        "operationId": "Users7Borrow95Put",
+        "tags": [
+          "Users"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "Body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/MakeARequestToBorrowABookrequest"
+            }
+          },
+          {
+            "name": "bookId",
+            "in": "path",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "name": "userId",
+            "in": "path",
+            "required": true,
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/MakeARequestToBorrowABookresponse"
+            },
+            "examples": {
+              "application/json": {
+                "message": "Successful",
+                "request": {
+                  "status": "Pending",
+                  "id": 6,
+                  "bookId": 99,
+                  "userId": 6,
+                  "reason": "Research",
+                  "returnDate": "2018-12-07T23:00:00Z",
+                  "comments": "Nil",
+                  "updatedAt": "2018-06-24T13:27:59.303Z",
+                  "createdAt": "2018-06-24T13:27:59.303Z"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The request cannot be fulfilled due to bad syntax.",
+            "schema": {
+              "$ref": "#/definitions/MakeARequestToBorrowABookerrorresponse"
+            },
+            "examples": {
+              "application/json": {
+                "message": "Unsuccessful",
+                "error": "ValidationError: child \"params\" fails because [child \"bookId\" fails because [\"bookId\" must be a positive number]]"
+              }
+            }
+          },
+          "401": {
+            "description": "Similar to 403 Forbidden, but specifically for use when authentication is possible but has failed or not yet been provided. The response must include a WWW-Authenticate header field containing a challenge applicable to the requested resource.",
+            "schema": {
+              "$ref": "#/definitions/MakeARequestToBorrowABookerrorresponse"
+            },
+            "examples": {
+              "application/json": {
+                "message": "Unsuccessful",
+                "error": "No token provided"
+              }
+            }
+          },
+          "404": {
+            "description": "The requested resource could not be found but may be available again in the future. Subsequent requests by the client are permissible.",
+            "schema": {
+              "$ref": "#/definitions/MakeARequestToBorrowABookerrorresponse"
+            },
+            "examples": {
+              "application/json": {
+                "message": "Unsuccessful",
+                "error": "Book was not found"
+              }
+            }
+          },
+          "409": {
+            "description": "Indicates that the request could not be processed because of conflict in the request, such as an edit conflict.",
+            "schema": {
+              "$ref": "#/definitions/MakeARequestToBorrowABookerrorresponse"
+            },
+            "examples": {
+              "application/json": {
+                "message": "Unsuccessful",
+                "error": "Already sent request"
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "userToken": []
+          }
+        ],
+        "x-unitTests": [
+          {
+            "request": {
+              "method": "POST",
+              "uri": "/users/7/borrow/95",
+              "headers": {
+                "Content-Type": "application/json"
+              },
+              "body": "{\"returnDate\":\"12/12/2018\",\"reason\":\"Research\",\"comments\":\"Nil\"}"
+            },
+            "expectedResponse": {
+              "x-allowExtraHeaders": true,
+              "x-bodyMatchMode": "RAW",
+              "x-arrayOrderedMatching": false,
+              "x-arrayCheckCount": false,
+              "x-matchResponseSchema": true,
+              "headers": {
+                "Connection": "keep-alive",
+                "Content-Length": "240",
+                "Content-Type": "application/json; charset=utf-8",
+                "Date": "Sun, 24 Jun 2018 13:27:59 GMT",
+                "ETag": "W/\"f0-LmX5A7aYtsrNVrlW7f/dfDq0zsI\"",
+                "X-Powered-By": "Express"
+              },
+              "body": "{\"message\":\"Successful\",\"request\":{\"status\":\"Pending\",\"id\":6,\"bookId\":99,\"userId\":6,\"reason\":\"Research\",\"returnDate\":\"2018-12-07T23:00:00Z\",\"comments\":\"Nil\",\"updatedAt\":\"2018-06-24T13:27:59.303Z\",\"createdAt\":\"2018-06-24T13:27:59.303Z\"}}"
+            },
+            "x-testShouldPass": true,
+            "x-testEnabled": true,
+            "x-testName": "Make a request to borrow a book",
+            "x-testDescription": "Endpoint for an admin to make a request to borrow a book. The request requires reason and returnDate, comments is optional"
+          }
+        ],
+        "x-operation-settings": {
+          "CollectParameters": false,
+          "AllowDynamicQueryParameters": false,
+          "AllowDynamicFormParameters": false,
+          "IsMultiContentStreaming": false
+        }
+      },
+      "put": {
+        "description": "Endpoint for an authenticated admin to accept or reject a request by the user to borrow a book. The admin must specify a status in the request which can be 'Accepted' or 'Declined'",
+        "summary": "Accept/reject a request to borrow a book",
+        "operationId": "Users8Borrow98Put",
+        "tags": [
+          "Users"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "Body",
+            "in": "body",
+            "required": true,
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/Accept~1rejectARequestToBorrowABookrequest"
+            }
+          },
+          {
+            "name": "bookId",
+            "in": "path",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "name": "userId",
+            "in": "path",
+            "required": true,
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/Accept~1rejectARequestToBorrowABookresponse"
+            },
+            "examples": {
+              "application/json": {
+                "message": "Successful",
+                "borrowRequest": {
+                  "id": 6,
+                  "reason": "Research",
+                  "comments": "Nil",
+                  "returnDate": "2018-12-07T23:00:00Z",
+                  "status": "Accepted",
+                  "createdAt": "2018-06-24T13:27:59.303Z",
+                  "updatedAt": "2018-06-24T13:34:31.161Z",
+                  "userId": 6,
+                  "bookId": 99
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The request cannot be fulfilled due to bad syntax.",
+            "schema": {
+              "$ref": "#/definitions/Accept~1rejectARequestToBorrowABookerrorresponse"
+            },
+            "examples": {
+              "application/json": {
+                "message": "Unsuccessful",
+                "error": "ValidationError: child \"body\" fails because [child \"status\" fails because [\"status\" must be one of [Declined, Accepted]]]"
+              }
+            }
+          },
+          "401": {
+            "description": "Similar to 403 Forbidden, but specifically for use when authentication is possible but has failed or not yet been provided. The response must include a WWW-Authenticate header field containing a challenge applicable to the requested resource.",
+            "schema": {
+              "$ref": "#/definitions/Accept~1rejectARequestToBorrowABookerrorresponse"
+            },
+            "examples": {
+              "application/json": {
+                "message": "Unsuccessful",
+                "error": "No token provided"
+              }
+            }
+          },
+          "403": {
+            "description": "The request was a legal request, but the server is refusing to respond to it. Unlike a 401 Unauthorized response, authenticating will make no difference.",
+            "schema": {
+              "$ref": "#/definitions/Accept~1rejectARequestToBorrowABookerrorresponse"
+            },
+            "examples": {
+              "application/json": {
+                "message": "Unsuccessful",
+                "error": "You must be an admin to access this feature"
+              }
+            }
+          },
+          "404": {
+            "description": "The requested resource could not be found but may be available again in the future. Subsequent requests by the client are permissible.",
+            "schema": {
+              "$ref": "#/definitions/Accept~1rejectARequestToBorrowABookerrorresponse"
+            },
+            "examples": {
+              "application/json": {
+                "message": "Unsuccessful",
+                "error": "Borrow request not found"
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "adminToken": []
+          }
+        ],
+        "x-unitTests": [
+          {
+            "request": {
+              "method": "PUT",
+              "uri": "/users/8/borrow/98",
+              "headers": {
+                "Content-Type": "application/json"
+              },
+              "body": "{\"status\":\"Declined\"}"
+            },
+            "expectedResponse": {
+              "x-allowExtraHeaders": true,
+              "x-bodyMatchMode": "RAW",
+              "x-arrayOrderedMatching": false,
+              "x-arrayCheckCount": false,
+              "x-matchResponseSchema": true,
+              "headers": {
+                "Connection": "keep-alive",
+                "Content-Length": "247",
+                "Content-Type": "application/json; charset=utf-8",
+                "Date": "Sun, 24 Jun 2018 13:34:31 GMT",
+                "ETag": "W/\"f7-SsyUDcavAPJdCzN3xogi8A0wo3c\"",
+                "X-Powered-By": "Express"
+              },
+              "body": "{\"message\":\"Successful\",\"borrowRequest\":{\"id\":6,\"reason\":\"Research\",\"comments\":\"Nil\",\"returnDate\":\"2018-12-07T23:00:00Z\",\"status\":\"Accepted\",\"createdAt\":\"2018-06-24T13:27:59.303Z\",\"updatedAt\":\"2018-06-24T13:34:31.161Z\",\"userId\":6,\"bookId\":99}}"
+            },
+            "x-testShouldPass": true,
+            "x-testEnabled": true,
+            "x-testName": "Accept/reject a request to borrow a book",
+            "x-testDescription": "Endpoint for an authenticated admin to accept or reject a request by the user to borrow a book. The admin must specify a status in the request which can be 'Accepted' or 'Declined'"
+          }
+        ],
+        "x-operation-settings": {
+          "CollectParameters": false,
+          "AllowDynamicQueryParameters": false,
+          "AllowDynamicFormParameters": false,
+          "IsMultiContentStreaming": false
+        }
+      }
+    },
+    "/books": {
+      "get": {
+        "description": "",
+        "summary": "Get books",
+        "operationId": "BooksGet2",
+        "tags": [
+          "Books"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "sort",
+            "in": "query",
+            "type": "string",
+            "description": "\"upvotes\" or \"downvotes\""
+          },
+          {
+            "name": "order",
+            "in": "query",
+            "type": "string",
+            "description": "\"desc\" or \"asc\""
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "type": "integer",
+            "description": "The page to be retrieved"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "type": "integer",
+            "description": "The limit of books to retrieve"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/GetBooksresponse"
+            },
+            "examples": {
+              "application/json": {
+                "message": "Successful",
+                "books": [
+                  {
+                    "id": 96,
+                    "title": "Love and Ruin",
+                    "author": "Paul McClain",
+                    "description": "Magnolia Table is infused with Joanna Gaines' warmth and passion for all things family, prepared and served straight from the heart of her home, with recipes inspired by dozens of Gaines family favorites and classic comfort selections from the couple's new Waco restaurant, Magnolia Table",
+                    "subject": "Romance",
+                    "imageURL": "https://images-na.ssl-images-amazon.com/images/I/51keKmj6MSL._SX327_BO1,204,203,200_.jpg",
+                    "quantity": 20,
+                    "borrowCount": 1,
+                    "favCount": 0,
+                    "upvotes": 1,
+                    "downvotes": 0,
+                    "createdAt": "2018-05-10T03:11:52.181Z",
+                    "updatedAt": "2018-06-22T12:22:48.895Z",
+                    "bookReviews": []
+                  },
+                  {
+                    "id": 1,
+                    "title": "Lean In",
+                    "author": "Sheryl Sandberg",
+                    "description": "A guide on how women can balance career and family",
+                    "subject": "Self-help",
+                    "imageURL": "https://res.cloudinary.com/ama-hello-books-v2/image/upload/v1529657777/Lean_In__book_cr3jst.jpg",
+                    "quantity": 20,
+                    "borrowCount": 0,
+                    "favCount": 0,
+                    "upvotes": 1,
+                    "downvotes": 0,
+                    "createdAt": "2018-06-22T08:56:20.614Z",
+                    "updatedAt": "2018-06-22T12:22:28.308Z",
+                    "bookReviews": []
+                  }
+                ],
+                "pagination": {
+                  "pageCount": 1,
+                  "pageSize": 2,
+                  "currentPage": 1,
+                  "bookCount": 2
+                }
+              }
+            }
+          }
+        },
+        "x-unitTests": [
+          {
+            "request": {
+              "method": "GET",
+              "uri": "/books?sort=upvotes&order=desc"
+            },
+            "expectedResponse": {
+              "x-allowExtraHeaders": true,
+              "x-bodyMatchMode": "RAW",
+              "x-arrayOrderedMatching": false,
+              "x-arrayCheckCount": false,
+              "x-matchResponseSchema": true,
+              "headers": {
+                "Connection": "keep-alive",
+                "Content-Length": "1171",
+                "Content-Type": "application/json; charset=utf-8",
+                "Date": "Sat, 23 Jun 2018 19:37:55 GMT",
+                "ETag": "W/\"493-bSaYQp4ftL9/RIG4twG/W2FvS4o\"",
+                "X-Powered-By": "Express"
+              },
+              "body": "{\"message\":\"Successful\",\"books\":[{\"id\":96,\"title\":\"Love and Ruin\",\"author\":\"Paul McClain\",\"description\":\"Magnolia Table is infused with Joanna Gaines' warmth and passion for all things family, prepared and served straight from the heart of her home, with recipes inspired by dozens of Gaines family favorites and classic comfort selections from the couple's new Waco restaurant, Magnolia Table\",\"subject\":\"Romance\",\"imageURL\":\"https://images-na.ssl-images-amazon.com/images/I/51keKmj6MSL._SX327_BO1,204,203,200_.jpg\",\"quantity\":20,\"borrowCount\":1,\"favCount\":0,\"upvotes\":1,\"downvotes\":0,\"createdAt\":\"2018-05-10T03:11:52.181Z\",\"updatedAt\":\"2018-06-22T12:22:48.895Z\",\"bookReviews\":[]},{\"id\":1,\"title\":\"Lean In\",\"author\":\"Sheryl Sandberg\",\"description\":\"A guide on how women can balance career and family\",\"subject\":\"Self-help\",\"imageURL\":\"https://res.cloudinary.com/ama-hello-books-v2/image/upload/v1529657777/Lean_In__book_cr3jst.jpg\",\"quantity\":20,\"borrowCount\":0,\"favCount\":0,\"upvotes\":1,\"downvotes\":0,\"createdAt\":\"2018-06-22T08:56:20.614Z\",\"updatedAt\":\"2018-06-22T12:22:28.308Z\",\"bookReviews\":[]}],\"pagination\":{\"pageCount\":1,\"pageSize\":2,\"currentPage\":1,\"bookCount\":2}}"
+            },
+            "x-testShouldPass": true,
+            "x-testEnabled": true,
+            "x-testName": "Get books",
+            "x-testDescription": ""
+          }
+        ],
+        "x-operation-settings": {
+          "CollectParameters": false,
+          "AllowDynamicQueryParameters": false,
+          "AllowDynamicFormParameters": false,
+          "IsMultiContentStreaming": false
+        }
+      },
+      "post": {
+        "description": "Endpoint for an authenticated admin to add a book",
+        "summary": "Add a book",
+        "operationId": "BooksPost",
+        "tags": [
+          "Books"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "Body",
+            "in": "body",
+            "required": true,
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/AddABookrequest"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/AddABookresponse"
+            },
+            "examples": {
+              "application/json": {
+                "message": "Successful",
+                "bookEntry": {
+                  "borrowCount": 0,
+                  "favCount": 0,
+                  "upvotes": 0,
+                  "downvotes": 0,
+                  "id": 5,
+                  "title": "A new book",
+                  "author": "Stephen Covey",
+                  "description": "Dr. Covey's 7 Habits book is one of the most inspiring and impactful books ever written. Now you can enjoy and learn critical lessons about the habits of successful people that will enrich your life's experience",
+                  "subject": "Inspiration",
+                  "imageURL": "https://images-na.ssl-images-amazon.com/images/I/51fEYMhtHoL.jpg",
+                  "quantity": 20,
+                  "updatedAt": "2018-06-24T12:59:07.573Z",
+                  "createdAt": "2018-06-24T12:59:07.573Z"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The request cannot be fulfilled due to bad syntax.",
+            "schema": {
+              "$ref": "#/definitions/AddABookerrorresponse"
+            },
+            "examples": {
+              "application/json": {
+                "message": "Unsuccessful",
+                "error": "ValidationError: child \"imageURL\" fails because [\"imageURL\" is required]"
+              }
+            }
+          },
+          "401": {
+            "description": "Similar to 403 Forbidden, but specifically for use when authentication is possible but has failed or not yet been provided. The response must include a WWW-Authenticate header field containing a challenge applicable to the requested resource.",
+            "schema": {
+              "$ref": "#/definitions/AddABookerrorresponse"
+            },
+            "examples": {
+              "application/json": {
+                "message": "Unsuccessful",
+                "error": "No token provided"
+              }
+            }
+          },
+          "403": {
+            "description": "The request was a legal request, but the server is refusing to respond to it. Unlike a 401 Unauthorized response, authenticating will make no difference.",
+            "schema": {
+              "$ref": "#/definitions/AddABookerrorresponse"
+            },
+            "examples": {
+              "application/json": {
+                "message": "Unsuccessful",
+                "error": "You must be an admin to access this feature"
+              }
+            }
+          },
+          "409": {
+            "description": "Indicates that the request could not be processed because of conflict in the request, such as an edit conflict.",
+            "schema": {
+              "$ref": "#/definitions/AddABookerrorresponse"
+            },
+            "examples": {
+              "application/json": {
+                "message": "Unsuccessful",
+                "error": "A book with this title already exists. Input a different title"
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "adminToken": []
+          }
+        ],
+        "x-unitTests": [
+          {
+            "request": {
+              "method": "POST",
+              "uri": "/books",
+              "headers": {
+                "Content-Type": "application/json"
+              },
+              "body": "{\"title\":\"A new book\",\"author\":\"Stephen Covey\",\"description\":\"Dr. Covey's 7 Habits book is one of the most inspiring and impactful books ever written. Now you can enjoy and learn critical lessons about the habits of successful people that will enrich your life's experience\",\"quantity\":20,\"subject\":\"Inspiration\"}"
+            },
+            "expectedResponse": {
+              "x-allowExtraHeaders": true,
+              "x-bodyMatchMode": "RAW",
+              "x-arrayOrderedMatching": false,
+              "x-arrayCheckCount": false,
+              "x-matchResponseSchema": true,
+              "headers": {
+                "Connection": "keep-alive",
+                "Content-Length": "568",
+                "Content-Type": "application/json; charset=utf-8",
+                "Date": "Sun, 24 Jun 2018 12:59:07 GMT",
+                "ETag": "W/\"238-Fp98PesqZmrjpY79MNTJKw8/eK4\"",
+                "X-Powered-By": "Express"
+              },
+              "body": "{\"message\":\"Successful\",\"bookEntry\":{\"borrowCount\":0,\"favCount\":0,\"upvotes\":0,\"downvotes\":0,\"id\":5,\"title\":\"A new book\",\"author\":\"Stephen Covey\",\"description\":\"Dr. Covey's 7 Habits book is one of the most inspiring and impactful books ever written. Now you can enjoy and learn critical lessons about the habits of successful people that will enrich your life's experience\",\"subject\":\"Inspiration\",\"imageURL\":\"https://images-na.ssl-images-amazon.com/images/I/51fEYMhtHoL.jpg\",\"quantity\":20,\"updatedAt\":\"2018-06-24T12:59:07.573Z\",\"createdAt\":\"2018-06-24T12:59:07.573Z\"}}"
+            },
+            "x-testShouldPass": true,
+            "x-testEnabled": true,
+            "x-testName": "Add a book",
+            "x-testDescription": "Endpoint for an authenticated admin to add a book"
+          }
+        ],
+        "x-operation-settings": {
+          "CollectParameters": false,
+          "AllowDynamicQueryParameters": false,
+          "AllowDynamicFormParameters": false,
+          "IsMultiContentStreaming": false
+        }
+      }
+    },
+    "/users/{userId}/return/{bookId}": {
+      "post": {
+        "description": "Endpoint for an authenticated user to return a book that has beeen borrowed",
+        "summary": "Send a request to return a borrowed book",
+        "operationId": "Users6Return99Post",
+        "tags": [
+          "Users"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "name": "bookId",
+            "in": "path",
+            "required": true,
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/SendARequestToReturnABorrowedBookresponse"
+            },
+            "examples": {
+              "application/json": {
+                "message": "Successful",
+                "returnRequest": {
+                  "id": 5,
+                  "comments": "null",
+                  "status": "Pending",
+                  "createdAt": "\"2018-06-24T13:39:42.424Z\"",
+                  "updatedAt": "\"2018-06-24T13:39:42.424Z\"",
+                  "userId": 6,
+                  "bookId": 99,
+                  "returnRequests": {
+                    "title": "New title",
+                    "author": "New author"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The request cannot be fulfilled due to bad syntax.",
+            "schema": {
+              "$ref": "#/definitions/SendARequestToReturnABorrowedBookerrorresponse"
+            },
+            "examples": {
+              "application/json": {
+                "message": "Unsuccessful",
+                "error": "ValidationError: child \"params\" fails because [child \"bookId\" fails because [\"bookId\" must be a positive number]]"
+              }
+            }
+          },
+          "401": {
+            "description": "Similar to 403 Forbidden, but specifically for use when authentication is possible but has failed or not yet been provided. The response must include a WWW-Authenticate header field containing a challenge applicable to the requested resource.",
+            "schema": {
+              "$ref": "#/definitions/SendARequestToReturnABorrowedBookerrorresponse"
+            },
+            "examples": {
+              "application/json": {
+                "message": "Unsuccessful",
+                "error": "No token provided"
+              }
+            }
+          },
+          "409": {
+            "description": "Indicates that the request could not be processed because of conflict in the request, such as an edit conflict.",
+            "schema": {
+              "$ref": "#/definitions/SendARequestToReturnABorrowedBookerrorresponse"
+            },
+            "examples": {
+              "application/json": {
+                "message": "Unsuccessful",
+                "error": "Your request has already been sent"
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "userToken": []
+          }
+        ],
+        "x-unitTests": [
+          {
+            "request": {
+              "method": "POST",
+              "uri": "/users/6/return/-99",
+              "headers": {
+                "Content-Type": "application/x-www-form-urlencoded"
+              }
+            },
+            "expectedResponse": {
+              "x-allowExtraHeaders": true,
+              "x-bodyMatchMode": "RAW",
+              "x-arrayOrderedMatching": false,
+              "x-arrayCheckCount": false,
+              "x-matchResponseSchema": true,
+              "headers": {
+                "Connection": "keep-alive",
+                "Content-Length": "246",
+                "Content-Type": "application/json; charset=utf-8",
+                "Date": "Sun, 24 Jun 2018 13:39:42 GMT",
+                "ETag": "W/\"f6-/UEudicQeCx1qEB6kD71lgdhSWs\"",
+                "X-Powered-By": "Express"
+              },
+              "body": "{\"message\":\"Successful\",\"returnRequest\":{\"id\":5,\"comments\":\"null\",\"status\":\"Pending\",\"createdAt\":\"\\\"2018-06-24T13:39:42.424Z\\\"\",\"updatedAt\":\"\\\"2018-06-24T13:39:42.424Z\\\"\",\"userId\":6,\"bookId\":99,\"returnRequests\":{\"title\":\"New title\",\"author\":\"New author\"}}}"
+            },
+            "x-testShouldPass": true,
+            "x-testEnabled": true,
+            "x-testName": "Send a request to return a borrowed book",
+            "x-testDescription": "Endpoint for an authenticated user to return a book that has beeen borrowed"
+          }
+        ],
+        "x-operation-settings": {
+          "CollectParameters": false,
+          "AllowDynamicQueryParameters": false,
+          "AllowDynamicFormParameters": false,
+          "IsMultiContentStreaming": false
+        }
+      },
+      "put": {
+        "description": "Endpoint for an authenticated admin to accept/reject a user's request to return a book",
+        "summary": "Accept/reject a request by a user to return a book",
+        "operationId": "Users6Return99Put",
+        "tags": [
+          "Users"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "Body",
+            "in": "body",
+            "required": true,
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/Accept~1rejectARequestByAUserToReturnABookrequest"
+            }
+          },
+          {
+            "name": "userId",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "bookId",
+            "in": "path",
+            "required": true,
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/Accept~1rejectARequestByAUserToReturnABookresponse"
+            },
+            "examples": {
+              "application/json": {
+                "message": "Successful",
+                "returnRequest": {
+                  "id": 5,
+                  "status": "Returned",
+                  "createdAt": "2018-06-24T13:34:31.172Z",
+                  "updatedAt": "2018-06-24T13:46:22.856Z",
+                  "userId": 6,
+                  "bookId": 99
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Similar to 403 Forbidden, but specifically for use when authentication is possible but has failed or not yet been provided. The response must include a WWW-Authenticate header field containing a challenge applicable to the requested resource.",
+            "schema": {
+              "$ref": "#/definitions/Accept~1rejectARequestByAUserToReturnABookerrorresponse"
+            },
+            "examples": {
+              "application/json": {
+                "message": "Unsuccessful",
+                "error": "No token provided"
+              }
+            }
+          },
+          "403": {
+            "description": "The request was a legal request, but the server is refusing to respond to it. Unlike a 401 Unauthorized response, authenticating will make no difference.",
+            "schema": {
+              "$ref": "#/definitions/Accept~1rejectARequestByAUserToReturnABookerrorresponse"
+            },
+            "examples": {
+              "application/json": {
+                "message": "Unsuccessful",
+                "error": "You must be an admin to access this feature"
+              }
+            }
+          },
+          "404": {
+            "description": "The requested resource could not be found but may be available again in the future. Subsequent requests by the client are permissible.",
+            "schema": {
+              "$ref": "#/definitions/Accept~1rejectARequestByAUserToReturnABookerrorresponse"
+            },
+            "examples": {
+              "application/json": {
+                "message": "Unsuccessful",
+                "error": "Return request not found"
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "adminToken": []
+          }
+        ],
+        "x-unitTests": [
+          {
+            "request": {
+              "method": "PUT",
+              "uri": "/users/6/return/99",
+              "headers": {
+                "Content-Type": "application/json"
+              },
+              "body": "{\"status\":\"Accepted\"}"
+            },
+            "expectedResponse": {
+              "x-allowExtraHeaders": true,
+              "x-bodyMatchMode": "RAW",
+              "x-arrayOrderedMatching": false,
+              "x-arrayCheckCount": false,
+              "x-matchResponseSchema": true,
+              "headers": {
+                "Connection": "keep-alive",
+                "Content-Length": "170",
+                "Content-Type": "application/json; charset=utf-8",
+                "Date": "Sun, 24 Jun 2018 13:46:22 GMT",
+                "ETag": "W/\"aa-ILdJYZq0K09jMlrCiuY+F/IY218\"",
+                "X-Powered-By": "Express"
+              },
+              "body": "{\"message\":\"Successful\",\"returnRequest\":{\"id\":5,\"status\":\"Returned\",\"createdAt\":\"2018-06-24T13:34:31.172Z\",\"updatedAt\":\"2018-06-24T13:46:22.856Z\",\"userId\":6,\"bookId\":99}}"
+            },
+            "x-testShouldPass": true,
+            "x-testEnabled": true,
+            "x-testName": "Accept/reject a request by a user to return a book",
+            "x-testDescription": "Endpoint for an authenticated admin to accept/reject a user's request to return a book"
+          }
+        ],
+        "x-operation-settings": {
+          "CollectParameters": false,
+          "AllowDynamicQueryParameters": false,
+          "AllowDynamicFormParameters": false,
+          "IsMultiContentStreaming": false
+        }
+      }
+    },
+    "/books/search": {
+      "post": {
+        "description": "Endpoint to search for a book based on title, author or subject. Only one query can be sent at a time.",
+        "summary": "Search for a book in the database",
+        "operationId": "BooksSearchPost",
+        "tags": [
+          "Books"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "title",
+            "in": "query",
+            "type": "string"
+          },
+          {
+            "name": "author",
+            "in": "query",
+            "type": "string"
+          },
+          {
+            "name": "subject",
+            "in": "query",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/SearchForABookInTheDatabaseresponse"
+            },
+            "examples": {
+              "application/json": {
+                "message": "Successful",
+                "books": [
+                  {
+                    "id": 94,
+                    "title": "Macbeth",
+                    "author": "A.J.Hartley",
+                    "description": "Macbeth: A Novel brings the intricacy and grit of the historical thriller to Shakespeare's tale of political intrigue, treachery, and murder.",
+                    "subject": "Romance",
+                    "imageURL": "https://images-na.ssl-images-amazon.com/images/I/51l6MwpodJL._AA300_.jpg",
+                    "quantity": 70,
+                    "borrowCount": 0,
+                    "favCount": 0,
+                    "upvotes": 0,
+                    "downvotes": 0,
+                    "createdAt": "2018-05-10T03:11:52.181Z",
+                    "updatedAt": "2018-05-10T03:11:52.181Z",
+                    "bookReviews": []
+                  }
+                ],
+                "pagination": {
+                  "pageCount": 1,
+                  "pageSize": 1,
+                  "currentPage": 1,
+                  "bookCount": 1
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "$ref": "#/definitions/SearchForABookInTheDatabaseerrorresponse"
+            },
+            "examples": {
+              "application/json": {
+                "message": "Unsuccessful",
+                "error": "ValidationError: child \"query\" fails because [\"name\" is not allowed]"
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "schema": {
+              "$ref": "#/definitions/SearchForABookInTheDatabaseerrorresponse"
+            },
+            "examples": {
+              "application/json": {
+                "message": "Successful",
+                "error": "No book matches search query"
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "auth": []
+          }
+        ],
+        "x-unitTests": [
+          {
+            "request": {
+              "method": "POST",
+              "uri": "/books/search?author=graace",
+              "headers": {
+                "Content-Type": "application/x-www-form-urlencoded"
+              }
+            },
+            "expectedResponse": {
+              "x-allowExtraHeaders": true,
+              "x-bodyMatchMode": "RAW",
+              "x-arrayOrderedMatching": false,
+              "x-arrayCheckCount": false,
+              "x-matchResponseSchema": true,
+              "headers": {
+                "Connection": "keep-alive",
+                "Content-Length": "585",
+                "Content-Type": "application/json; charset=utf-8",
+                "Date": "Sat, 23 Jun 2018 18:42:43 GMT",
+                "ETag": "W/\"249-F9kQxpZIvLeDTikFpD0WENvMv+Y\"",
+                "X-Powered-By": "Express"
+              },
+              "body": "{\"message\":\"Successful\",\"books\":[{\"id\":94,\"title\":\"Macbeth\",\"author\":\"A.J.Hartley\",\"description\":\"Macbeth: A Novel brings the intricacy and grit of the historical thriller to Shakespeare's tale of political intrigue, treachery, and murder.\",\"subject\":\"Romance\",\"imageURL\":\"https://images-na.ssl-images-amazon.com/images/I/51l6MwpodJL._AA300_.jpg\",\"quantity\":70,\"borrowCount\":0,\"favCount\":0,\"upvotes\":0,\"downvotes\":0,\"createdAt\":\"2018-05-10T03:11:52.181Z\",\"updatedAt\":\"2018-05-10T03:11:52.181Z\",\"bookReviews\":[]}],\"pagination\":{\"pageCount\":1,\"pageSize\":1,\"currentPage\":1,\"bookCount\":1}}"
+            },
+            "x-testShouldPass": true,
+            "x-testEnabled": true,
+            "x-testName": "Search for a book in the database",
+            "x-testDescription": "Endpoint to search for a book based on title, author or subject"
+          }
+        ],
+        "x-operation-settings": {
+          "CollectParameters": false,
+          "AllowDynamicQueryParameters": false,
+          "AllowDynamicFormParameters": false,
+          "IsMultiContentStreaming": false
+        }
+      }
+    },
+    "/books/{bookId}/favorite": {
+      "post": {
+        "description": "Endpoint for an authenticated user to mark a book as favourite",
+        "summary": "Mark a book as favorite",
+        "operationId": "Books98FavoritePost",
+        "tags": [
+          "Books"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "bookId",
+            "in": "path",
+            "required": true,
+            "type": "integer",
+            "description": ""
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/MarkABookAsFavoriteresponse"
+            },
+            "examples": {
+              "application/json": {
+                "message": "Successful",
+                "favorite": {
+                  "id": 2,
+                  "bookId": 99,
+                  "userId": 3,
+                  "updatedAt": "2018-06-23T19:14:10.907Z",
+                  "createdAt": "2018-06-23T19:14:10.907Z"
+                },
+                "book": {
+                  "id": 99,
+                  "title": "Lies That Bind Us",
+                  "author": "Andrew Hart",
+                  "description": "Jan needs this. She’s flying to Crete to reunite with friends she met there five years ago and relive an idyllic vacation. Basking in the warmth of the sun, the azure sea, and the aura of antiquity, she can once again pretend—for a little while—that she belongs. Her ex-boyfriend Marcus will be among them, but even he doesn’t know the secrets she keeps hidden behind a veil of lies. None of them really know her, and that’s only part of the problem.",
+                  "subject": "Fiction",
+                  "imageURL": "https://images-na.ssl-images-amazon.com/images/I/51SLlJ5SWOL.jpg",
+                  "quantity": 10,
+                  "borrowCount": 0,
+                  "favCount": 1,
+                  "upvotes": 0,
+                  "downvotes": 1,
+                  "createdAt": "2018-05-10T03:11:52.181Z",
+                  "updatedAt": "2018-06-23T19:14:10.925Z"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "$ref": "#/definitions/MarkABookAsFavoriteerrorresponse"
+            },
+            "examples": {
+              "application/json": {
+                "message": "Unsuccessful",
+                "error": "ValidationError: child \"params\" fails because [child \"bookId\" fails because [\"bookId\" must be a positive number]]"
+              }
+            }
+          },
+          "401": {
+            "description": "Similar to 403 Forbidden, but specifically for use when authentication is possible but has failed or not yet been provided. The response must include a WWW-Authenticate header field containing a challenge applicable to the requested resource.",
+            "schema": {
+              "$ref": "#/definitions/MarkABookAsFavoriteerrorresponse"
+            },
+            "examples": {
+              "application/json": {
+                "message": "Unsuccessful",
+                "error": "No token provided"
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "schema": {
+              "$ref": "#/definitions/MarkABookAsFavoriteerrorresponse"
+            },
+            "examples": {
+              "application/json": {
+                "message": "Unsuccessful",
+                "error": "Book was not found"
+              }
+            }
+          },
+          "409": {
+            "description": "Indicates that the request could not be processed because of conflict in the request, such as an edit conflict.",
+            "schema": {
+              "$ref": "#/definitions/MarkABookAsFavoriteerrorresponse"
+            },
+            "examples": {
+              "application/json": {
+                "message": "Unsuccessful",
+                "error": "Already favorited book"
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "userToken": []
+          }
+        ],
+        "x-unitTests": [
+          {
+            "request": {
+              "method": "POST",
+              "uri": "/books/98/favorite",
+              "headers": {
+                "Content-Type": "application/json"
+              }
+            },
+            "expectedResponse": {
+              "x-allowExtraHeaders": true,
+              "x-bodyMatchMode": "RAW",
+              "x-arrayOrderedMatching": false,
+              "x-arrayCheckCount": false,
+              "x-matchResponseSchema": true,
+              "headers": {
+                "Connection": "keep-alive",
+                "Content-Length": "935",
+                "Content-Type": "application/json; charset=utf-8",
+                "Date": "Sat, 23 Jun 2018 19:14:10 GMT",
+                "ETag": "W/\"3a7-4nzW63DY6wVu5nvs1pnmYOix9Pc\"",
+                "X-Powered-By": "Express"
+              },
+              "body": "{\"message\":\"Successful\",\"favorite\":{\"id\":2,\"bookId\":99,\"userId\":3,\"updatedAt\":\"2018-06-23T19:14:10.907Z\",\"createdAt\":\"2018-06-23T19:14:10.907Z\"},\"book\":{\"id\":99,\"title\":\"Lies That Bind Us\",\"author\":\"Andrew Hart\",\"description\":\"Jan needs this. She’s flying to Crete to reunite with friends she met there five years ago and relive an idyllic vacation. Basking in the warmth of the sun, the azure sea, and the aura of antiquity, she can once again pretend—for a little while—that she belongs. Her ex-boyfriend Marcus will be among them, but even he doesn’t know the secrets she keeps hidden behind a veil of lies. None of them really know her, and that’s only part of the problem.\",\"subject\":\"Fiction\",\"imageURL\":\"https://images-na.ssl-images-amazon.com/images/I/51SLlJ5SWOL.jpg\",\"quantity\":10,\"borrowCount\":0,\"favCount\":1,\"upvotes\":0,\"downvotes\":1,\"createdAt\":\"2018-05-10T03:11:52.181Z\",\"updatedAt\":\"2018-06-23T19:14:10.925Z\"}}"
+            },
+            "x-testShouldPass": true,
+            "x-testEnabled": true,
+            "x-testName": "Mark a book as favorite",
+            "x-testDescription": "Endpoint for an authenticated user to mark a book as favourite"
+          }
+        ],
+        "x-operation-settings": {
+          "CollectParameters": false,
+          "AllowDynamicQueryParameters": false,
+          "AllowDynamicFormParameters": false,
+          "IsMultiContentStreaming": false
+        }
+      }
+    },
+    "/books/{bookId}": {
+      "get": {
+        "description": "Endpoint to get a book from the database. The bookId should be specified in the request.",
+        "summary": "Get a book",
+        "operationId": "BooksTrGet",
+        "tags": [
+          "Books"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "bookId",
+            "in": "path",
+            "required": true,
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "$ref": "#/definitions/GetABookresponse"
+            },
+            "examples": {
+              "application/json": {
+                "message": "Successful",
+                "book": {
+                  "id": 1,
+                  "title": "Lean In",
+                  "author": "Sheryl Sandberg",
+                  "description": "A guide on how women can balance career and family",
+                  "subject": "Self-help",
+                  "imageURL": "https://res.cloudinary.com/ama-hello-books-v2/image/upload/v1529657777/Lean_In__book_cr3jst.jpg",
+                  "quantity": 20,
+                  "borrowCount": 0,
+                  "favCount": 0,
+                  "upvotes": 1,
+                  "downvotes": 0,
+                  "createdAt": "2018-06-22T08:56:20.614Z",
+                  "updatedAt": "2018-06-22T12:22:28.308Z",
+                  "bookReviews": []
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The request cannot be fulfilled due to bad syntax.",
+            "schema": {
+              "$ref": "#/definitions/GetABookerrorresponse"
+            },
+            "examples": {
+              "application/json": {
+                "message": "Unsuccessful",
+                "error": "ValidationError: child \"params\" fails because [child \"bookId\" fails because [\"bookId\" must be a positive number]]"
+              }
+            }
+          },
+          "404": {
+            "description": "The requested resource could not be found but may be available again in the future. Subsequent requests by the client are permissible.",
+            "schema": {
+              "$ref": "#/definitions/GetABookerrorresponse"
+            },
+            "examples": {
+              "application/json": {
+                "message": "Unsuccessful",
+                "error": "Book was not found"
+              }
+            }
+          }
+        },
+        "x-unitTests": [
+          {
+            "request": {
+              "method": "GET",
+              "uri": "/books/tr"
+            },
+            "expectedResponse": {
+              "x-allowExtraHeaders": true,
+              "x-bodyMatchMode": "RAW",
+              "x-arrayOrderedMatching": false,
+              "x-arrayCheckCount": false,
+              "x-matchResponseSchema": true,
+              "headers": {
+                "Connection": "keep-alive",
+                "Content-Length": "447",
+                "Content-Type": "application/json; charset=utf-8",
+                "Date": "Sat, 23 Jun 2018 15:54:31 GMT",
+                "ETag": "W/\"1bf-syIgZrxbVE2SEjN2qDNi8VW4tM8\"",
+                "X-Powered-By": "Express"
+              },
+              "body": "{\"message\":\"Successful\",\"book\":{\"id\":1,\"title\":\"Lean In\",\"author\":\"Sheryl Sandberg\",\"description\":\"A guide on how women can balance career and family\",\"subject\":\"Self-help\",\"imageURL\":\"https://res.cloudinary.com/ama-hello-books-v2/image/upload/v1529657777/Lean_In__book_cr3jst.jpg\",\"quantity\":20,\"borrowCount\":0,\"favCount\":0,\"upvotes\":1,\"downvotes\":0,\"createdAt\":\"2018-06-22T08:56:20.614Z\",\"updatedAt\":\"2018-06-22T12:22:28.308Z\",\"bookReviews\":[]}}"
+            },
+            "x-testShouldPass": true,
+            "x-testEnabled": true,
+            "x-testName": "Get a book",
+            "x-testDescription": "Endpoint to get a book from the database. The bookId should be specified in the request."
+          }
+        ],
+        "x-operation-settings": {
+          "CollectParameters": false,
+          "AllowDynamicQueryParameters": false,
+          "AllowDynamicFormParameters": false,
+          "IsMultiContentStreaming": false
+        }
+      },
+      "put": {
+        "description": "Endpoint for an authenticated admin to modify details of a book",
+        "summary": "Modify a book",
+        "operationId": "Books1Put",
+        "tags": [
+          "Books"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "Body",
+            "in": "body",
+            "required": true,
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/AddABookrequest"
+            }
+          },
+          {
+            "name": "bookId",
+            "in": "path",
+            "required": true,
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/ModifyABookresponse"
+            },
+            "examples": {
+              "application/json": {
+                "message": "Successful",
+                "updatedBook": {
+                  "id": 99,
+                  "title": "New title",
+                  "author": "New author",
+                  "description": "Jan needs this. She’s flying to Crete to reunite with friends she met there five years ago and relive an idyllic vacation. Basking in the warmth of the sun, the azure sea, and the aura of antiquity, she can once again pretend—for a little while—that she belongs. Her ex-boyfriend Marcus will be among them, but even he doesn’t know the secrets she keeps hidden behind a veil of lies. None of them really know her, and that’s only part of the problem.",
+                  "subject": "Fiction",
+                  "imageURL": "https://images-na.ssl-images-amazon.com/images/I/51SLlJ5SWOL.jpg",
+                  "quantity": 10,
+                  "borrowCount": 1,
+                  "favCount": 1,
+                  "upvotes": 0,
+                  "downvotes": 1,
+                  "createdAt": "2018-05-10T03:11:52.181Z",
+                  "updatedAt": "2018-06-24T13:07:04.634Z"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The request cannot be fulfilled due to bad syntax.",
+            "schema": {
+              "$ref": "#/definitions/ModifyABookerrorresponse"
+            },
+            "examples": {
+              "application/json": {
+                "message": "Unsuccessful",
+                "error": "ValidationError: child \"params\" fails because [child \"bookId\" fails because [\"bookId\" must be a positive number]]"
+              }
+            }
+          },
+          "403": {
+            "description": "The request was a legal request, but the server is refusing to respond to it. Unlike a 401 Unauthorized response, authenticating will make no difference.",
+            "schema": {
+              "$ref": "#/definitions/ModifyABookerrorresponse"
+            },
+            "examples": {
+              "application/json": {
+                "message": "Unsuccessful",
+                "error": "You must be an admin to access this feature"
+              }
+            }
+          },
+          "404": {
+            "description": "The requested resource could not be found but may be available again in the future. Subsequent requests by the client are permissible.",
+            "schema": {
+              "$ref": "#/definitions/ModifyABookerrorresponse"
+            },
+            "examples": {
+              "application/json": {
+                "message": "Unsuccessful",
+                "error": "Book was not found"
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "adminToken": []
+          }
+        ],
+        "x-unitTests": [
+          {
+            "request": {
+              "method": "PUT",
+              "uri": "/books/1",
+              "headers": {
+                "Content-Type": "application/json"
+              },
+              "body": "{\"title\":\"A new book\",\"author\":\"Stephen Covey\",\"description\":\"Dr. Covey's 7 Habits book is one of the most inspiring and impactful books ever written. Now you can enjoy and learn critical lessons about the habits of successful people that will enrich your life's experience\",\"quantity\":20,\"subject\":\"Inspiration\"}"
+            },
+            "expectedResponse": {
+              "x-allowExtraHeaders": true,
+              "x-bodyMatchMode": "RAW",
+              "x-arrayOrderedMatching": false,
+              "x-arrayCheckCount": false,
+              "x-matchResponseSchema": true,
+              "headers": {
+                "Connection": "keep-alive",
+                "Content-Length": "812",
+                "Content-Type": "application/json; charset=utf-8",
+                "Date": "Sun, 24 Jun 2018 13:07:04 GMT",
+                "ETag": "W/\"32c-IJvoyxruxv0W2gJAwq5HSZn95PA\"",
+                "X-Powered-By": "Express"
+              },
+              "body": "{\"message\":\"Successful\",\"updatedBook\":{\"id\":99,\"title\":\"New title\",\"author\":\"New author\",\"description\":\"Jan needs this. She’s flying to Crete to reunite with friends she met there five years ago and relive an idyllic vacation. Basking in the warmth of the sun, the azure sea, and the aura of antiquity, she can once again pretend—for a little while—that she belongs. Her ex-boyfriend Marcus will be among them, but even he doesn’t know the secrets she keeps hidden behind a veil of lies. None of them really know her, and that’s only part of the problem.\",\"subject\":\"Fiction\",\"imageURL\":\"https://images-na.ssl-images-amazon.com/images/I/51SLlJ5SWOL.jpg\",\"quantity\":10,\"borrowCount\":1,\"favCount\":1,\"upvotes\":0,\"downvotes\":1,\"createdAt\":\"2018-05-10T03:11:52.181Z\",\"updatedAt\":\"2018-06-24T13:07:04.634Z\"}}"
+            },
+            "x-testShouldPass": true,
+            "x-testEnabled": true,
+            "x-testName": "Modify a book",
+            "x-testDescription": "Endpoint for an authenticated admin to modify details of a book"
+          }
+        ],
+        "x-operation-settings": {
+          "CollectParameters": false,
+          "AllowDynamicQueryParameters": false,
+          "AllowDynamicFormParameters": false,
+          "IsMultiContentStreaming": false
+        }
+      },
+      "delete": {
+        "description": "Endpoint for an authenticated admin to delete a book",
+        "summary": "Delete  a book",
+        "operationId": "Books98Delete",
+        "tags": [
+          "Books"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "bookId",
+            "in": "path",
+            "required": true,
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "",
+            "schema": {
+              "type": "object"
+            },
+            "examples": {}
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "$ref": "#/definitions/DeleteABookerrorresponse"
+            },
+            "examples": {
+              "application/json": {
+                "message": "Unsuccessful",
+                "error": "bookId must be a positive integer"
+              }
+            }
+          },
+          "401": {
+            "description": "Similar to 403 Forbidden, but specifically for use when authentication is possible but has failed or not yet been provided. The response must include a WWW-Authenticate header field containing a challenge applicable to the requested resource.",
+            "schema": {
+              "$ref": "#/definitions/DeleteABookerrorresponse"
+            },
+            "examples": {
+              "application/json": {
+                "message": "Unsuccessful",
+                "error": "No token provided"
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "schema": {
+              "$ref": "#/definitions/DeleteABookerrorresponse"
+            },
+            "examples": {
+              "application/json": {
+                "message": "Unsuccessful",
+                "error": "You must be an admin to access this feature"
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "schema": {
+              "$ref": "#/definitions/DeleteABookerrorresponse"
+            },
+            "examples": {
+              "application/json": {
+                "message": "Unsuccessful",
+                "error": "Book was not found"
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "adminToken": []
+          }
+        ],
+        "x-unitTests": [
+          {
+            "request": {
+              "method": "DELETE",
+              "uri": "/books/98",
+              "headers": {
+                "Content-Type": "application/json"
+              }
+            },
+            "expectedResponse": {
+              "x-allowExtraHeaders": true,
+              "x-bodyMatchMode": "NONE",
+              "x-arrayOrderedMatching": false,
+              "x-arrayCheckCount": false,
+              "x-matchResponseSchema": true,
+              "headers": {
+                "Connection": "keep-alive",
+                "Date": "Sat, 23 Jun 2018 19:32:11 GMT",
+                "ETag": "W/\"2-vyGp6PvFo4RvsFtPoIWeCReyIC8\"",
+                "X-Powered-By": "Express"
+              }
+            },
+            "x-testShouldPass": true,
+            "x-testEnabled": true,
+            "x-testName": "Delete  a book",
+            "x-testDescription": "Endpoint for an authenticated admin to delete a book"
+          }
+        ],
+        "x-operation-settings": {
+          "CollectParameters": false,
+          "AllowDynamicQueryParameters": false,
+          "AllowDynamicFormParameters": false,
+          "IsMultiContentStreaming": false
+        }
+      }
+    },
+    "/books/{bookId}/review": {
+      "post": {
+        "description": "Endpoint to review a book in the application",
+        "summary": "Review a book",
+        "operationId": "Books1ReviewPost",
+        "tags": [
+          "Books"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "Body",
+            "in": "body",
+            "required": true,
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/ReviewABookrequest"
+            }
+          },
+          {
+            "name": "bookId",
+            "in": "path",
+            "required": true,
+            "type": "integer",
+            "description": ""
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/ReviewABookresponse"
+            },
+            "examples": {
+              "application/json": {
+                "message": "Successful",
+                "reviewedBook": {
+                  "id": 1,
+                  "title": "Lean In",
+                  "author": "Sheryl Sandberg",
+                  "description": "A guide on how women can balance career and family",
+                  "subject": "Self-help",
+                  "imageURL": "https://res.cloudinary.com/ama-hello-books-v2/image/upload/v1529657777/Lean_In__book_cr3jst.jpg",
+                  "quantity": 20,
+                  "borrowCount": 0,
+                  "favCount": 0,
+                  "upvotes": 1,
+                  "downvotes": 0,
+                  "createdAt": "\"2018-06-22T08:56:20.614Z\"",
+                  "updatedAt": "\"2018-06-22T12:22:28.308Z\"",
+                  "bookReviews": [
+                    {
+                      "id": 2,
+                      "review": "I enjoyed reading this book",
+                      "createdAt": "\"2018-06-24T13:18:52.295Z\"",
+                      "updatedAt": "\"2018-06-24T13:18:52.295Z\"",
+                      "userId": 3,
+                      "bookId": 1,
+                      "userReviews": {
+                        "id": 3,
+                        "firstName": "Grace",
+                        "lastName": "Jade",
+                        "imageURL": "null",
+                        "createdAt": "\"2018-06-23T14:42:46.827Z\""
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The request cannot be fulfilled due to bad syntax.",
+            "schema": {
+              "$ref": "#/definitions/ReviewABookerrorresponse"
+            },
+            "examples": {
+              "application/json": {
+                "message": "Unsuccessful",
+                "error": "ValidationError: child \"params\" fails because [child \"bookId\" fails because [\"bookId\" must be a positive number]]"
+              }
+            }
+          },
+          "401": {
+            "description": "Similar to 403 Forbidden, but specifically for use when authentication is possible but has failed or not yet been provided. The response must include a WWW-Authenticate header field containing a challenge applicable to the requested resource.",
+            "schema": {
+              "$ref": "#/definitions/ReviewABookerrorresponse"
+            },
+            "examples": {
+              "application/json": {
+                "message": "Unsuccessful",
+                "error": "No token provided"
+              }
+            }
+          },
+          "409": {
+            "description": "Indicates that the request could not be processed because of conflict in the request, such as an edit conflict.",
+            "schema": {
+              "$ref": "#/definitions/ReviewABookerrorresponse"
+            },
+            "examples": {
+              "application/json": {
+                "message": "Unsuccessful",
+                "error": "Your review has already been created"
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "userToken": []
+          }
+        ],
+        "x-unitTests": [
+          {
+            "request": {
+              "method": "POST",
+              "uri": "/books/1/review",
+              "headers": {
+                "Content-Type": "application/json"
+              },
+              "body": "{\"review\":\"\"}"
+            },
+            "expectedResponse": {
+              "x-allowExtraHeaders": true,
+              "x-bodyMatchMode": "RAW",
+              "x-arrayOrderedMatching": false,
+              "x-arrayCheckCount": false,
+              "x-matchResponseSchema": true,
+              "headers": {
+                "Connection": "keep-alive",
+                "Content-Length": "718",
+                "Content-Type": "application/json; charset=utf-8",
+                "Date": "Sun, 24 Jun 2018 13:18:52 GMT",
+                "ETag": "W/\"2ce-SXLNAi8rMe5SLPHUMFbnRaGZqd0\"",
+                "X-Powered-By": "Express"
+              },
+              "body": "{\"message\":\"Successful\",\"reviewedBook\":{\"id\":1,\"title\":\"Lean In\",\"author\":\"Sheryl Sandberg\",\"description\":\"A guide on how women can balance career and family\",\"subject\":\"Self-help\",\"imageURL\":\"https://res.cloudinary.com/ama-hello-books-v2/image/upload/v1529657777/Lean_In__book_cr3jst.jpg\",\"quantity\":20,\"borrowCount\":0,\"favCount\":0,\"upvotes\":1,\"downvotes\":0,\"createdAt\":\"\\\"2018-06-22T08:56:20.614Z\\\"\",\"updatedAt\":\"\\\"2018-06-22T12:22:28.308Z\\\"\",\"bookReviews\":[{\"id\":2,\"review\":\"I enjoyed reading this book\",\"createdAt\":\"\\\"2018-06-24T13:18:52.295Z\\\"\",\"updatedAt\":\"\\\"2018-06-24T13:18:52.295Z\\\"\",\"userId\":3,\"bookId\":1,\"userReviews\":{\"id\":3,\"firstName\":\"Grace\",\"lastName\":\"Jade\",\"imageURL\":\"null\",\"createdAt\":\"\\\"2018-06-23T14:42:46.827Z\\\"\"}}]}}"
+            },
+            "x-testShouldPass": true,
+            "x-testEnabled": true,
+            "x-testName": "Review a book",
+            "x-testDescription": "Endpoint to review a book in the application"
+          }
+        ],
+        "x-operation-settings": {
+          "CollectParameters": false,
+          "AllowDynamicQueryParameters": false,
+          "AllowDynamicFormParameters": false,
+          "IsMultiContentStreaming": false
+        }
+      }
+    },
+    "/books/{bookId}/upvote": {
+      "post": {
+        "description": "Endpoint for a user to upvote a book",
+        "summary": "Upvote a book",
+        "operationId": "Books88UpvotePost",
+        "tags": [
+          "Books"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "bookId",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/UpvoteABookresponse"
+            },
+            "examples": {
+              "application/json": {
+                "message": "Successful",
+                "vote": {
+                  "bookId": "4",
+                  "book": {
+                    "id": 4,
+                    "title": "A new book",
+                    "author": "An updated author",
+                    "description": "A book on romance",
+                    "subject": "Romance",
+                    "imageURL": "https://res.cloudinary.com/ama-hello-books-v2/image/upload/v1529657777/Lean_In__book_cr3jst.jpg",
+                    "quantity": 11,
+                    "borrowCount": 0,
+                    "favCount": 0,
+                    "upvotes": 1,
+                    "downvotes": 0,
+                    "createdAt": "2018-06-23T18:18:17.17Z",
+                    "updatedAt": "2018-06-23T18:57:04.307Z"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "$ref": "#/definitions/UpvoteABookerrorresponse"
+            },
+            "examples": {
+              "application/json": {
+                "message": "Unsuccessful",
+                "error": "ValidationError: child \"params\" fails because [child \"bookId\" fails because [\"bookId\" must be a positive number]]"
+              }
+            }
+          },
+          "401": {
+            "description": "Similar to 403 Forbidden, but specifically for use when authentication is possible but has failed or not yet been provided. The response must include a WWW-Authenticate header field containing a challenge applicable to the requested resource.",
+            "schema": {
+              "$ref": "#/definitions/UpvoteABookerrorresponse"
+            },
+            "examples": {
+              "application/json": {
+                "message": "Unsuccessful",
+                "error": "No token provided"
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "schema": {
+              "$ref": "#/definitions/UpvoteABookerrorresponse"
+            },
+            "examples": {
+              "application/json": {
+                "message": "Unsuccessful",
+                "error": "Book was not found"
+              }
+            }
+          },
+          "409": {
+            "description": "Indicates that the request could not be processed because of conflict in the request, such as an edit conflict.",
+            "schema": {
+              "$ref": "#/definitions/UpvoteABookerrorresponse"
+            },
+            "examples": {
+              "application/json": {
+                "message": "Unsuccessful",
+                "error": "You have already upvoted this book"
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "userToken": []
+          }
+        ],
+        "x-unitTests": [
+          {
+            "request": {
+              "method": "POST",
+              "uri": "/books/88/upvote",
+              "headers": {
+                "Content-Type": "application/x-www-form-urlencoded"
+              }
+            },
+            "expectedResponse": {
+              "x-allowExtraHeaders": true,
+              "x-bodyMatchMode": "RAW",
+              "x-arrayOrderedMatching": false,
+              "x-arrayCheckCount": false,
+              "x-matchResponseSchema": true,
+              "headers": {
+                "Connection": "keep-alive",
+                "Content-Length": "422",
+                "Content-Type": "application/json; charset=utf-8",
+                "Date": "Sat, 23 Jun 2018 18:57:04 GMT",
+                "ETag": "W/\"1a6-XC4N2fftoH1R9RM5M33q2upLapw\"",
+                "X-Powered-By": "Express"
+              },
+              "body": "{\"message\":\"Successful\",\"vote\":{\"bookId\":\"4\",\"book\":{\"id\":4,\"title\":\"A new book\",\"author\":\"An updated author\",\"description\":\"A book on romance\",\"subject\":\"Romance\",\"imageURL\":\"https://res.cloudinary.com/ama-hello-books-v2/image/upload/v1529657777/Lean_In__book_cr3jst.jpg\",\"quantity\":11,\"borrowCount\":0,\"favCount\":0,\"upvotes\":1,\"downvotes\":0,\"createdAt\":\"2018-06-23T18:18:17.17Z\",\"updatedAt\":\"2018-06-23T18:57:04.307Z\"}}}"
+            },
+            "x-testShouldPass": true,
+            "x-testEnabled": true,
+            "x-testName": "Upvote a book",
+            "x-testDescription": "Endpoint for a user to upvote a book"
+          }
+        ],
+        "x-operation-settings": {
+          "CollectParameters": false,
+          "AllowDynamicQueryParameters": false,
+          "AllowDynamicFormParameters": false,
+          "IsMultiContentStreaming": false
+        }
+      }
+    },
+    "/books/{bookId}/downvote": {
+      "post": {
+        "description": "Endpoint to downvote a book in the application",
+        "summary": "Downvote a book",
+        "operationId": "Books98DownvotePost",
+        "tags": [
+          "Books"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "bookId",
+            "in": "path",
+            "required": true,
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/DownvoteABookresponse"
+            },
+            "examples": {
+              "application/json": {
+                "message": "Successful",
+                "vote": {
+                  "bookId": "99",
+                  "book": {
+                    "id": 99,
+                    "title": "Lies That Bind Us",
+                    "author": "Andrew Hart",
+                    "description": "Jan needs this. She’s flying to Crete to reunite with friends she met there five years ago and relive an idyllic vacation. Basking in the warmth of the sun, the azure sea, and the aura of antiquity, she can once again pretend—for a little while—that she belongs. Her ex-boyfriend Marcus will be among them, but even he doesn’t know the secrets she keeps hidden behind a veil of lies. None of them really know her, and that’s only part of the problem.",
+                    "subject": "Fiction",
+                    "imageURL": "https://images-na.ssl-images-amazon.com/images/I/51SLlJ5SWOL.jpg",
+                    "quantity": 10,
+                    "borrowCount": 0,
+                    "favCount": 0,
+                    "upvotes": 0,
+                    "downvotes": 1,
+                    "createdAt": "2018-05-10T03:11:52.181Z",
+                    "updatedAt": "2018-06-23T19:05:19.889Z"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "$ref": "#/definitions/DownvoteABookerrorresponse"
+            },
+            "examples": {
+              "application/json": {
+                "message": "Unsuccessful",
+                "error": "ValidationError: child \"params\" fails because [child \"bookId\" fails because [\"bookId\" must be a positive number]]"
+              }
+            }
+          },
+          "401": {
+            "description": "Similar to 403 Forbidden, but specifically for use when authentication is possible but has failed or not yet been provided. The response must include a WWW-Authenticate header field containing a challenge applicable to the requested resource.",
+            "schema": {
+              "$ref": "#/definitions/DownvoteABookerrorresponse"
+            },
+            "examples": {
+              "application/json": {
+                "message": "Unsuccessful",
+                "error": "No token provided"
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "schema": {
+              "$ref": "#/definitions/DownvoteABookerrorresponse"
+            },
+            "examples": {
+              "application/json": {
+                "message": "Unsuccessful",
+                "error": "Book was not found"
+              }
+            }
+          },
+          "409": {
+            "description": "Indicates that the request could not be processed because of conflict in the request, such as an edit conflict.",
+            "schema": {
+              "$ref": "#/definitions/DownvoteABookerrorresponse"
+            },
+            "examples": {
+              "application/json": {
+                "message": "Unsuccessful",
+                "error": "You have already downvoted this book"
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "userToken": []
+          }
+        ],
+        "x-unitTests": [
+          {
+            "request": {
+              "method": "POST",
+              "uri": "/books/98/downvote"
+            },
+            "expectedResponse": {
+              "x-allowExtraHeaders": true,
+              "x-bodyMatchMode": "RAW",
+              "x-arrayOrderedMatching": false,
+              "x-arrayCheckCount": false,
+              "x-matchResponseSchema": true,
+              "headers": {
+                "Connection": "keep-alive",
+                "Content-Length": "837",
+                "Content-Type": "application/json; charset=utf-8",
+                "Date": "Sat, 23 Jun 2018 19:05:19 GMT",
+                "ETag": "W/\"345-gfsCuRVjEhgh+aQLvtma3VS+QZA\"",
+                "X-Powered-By": "Express"
+              },
+              "body": "{\"message\":\"Successful\",\"vote\":{\"bookId\":\"99\",\"book\":{\"id\":99,\"title\":\"Lies That Bind Us\",\"author\":\"Andrew Hart\",\"description\":\"Jan needs this. She’s flying to Crete to reunite with friends she met there five years ago and relive an idyllic vacation. Basking in the warmth of the sun, the azure sea, and the aura of antiquity, she can once again pretend—for a little while—that she belongs. Her ex-boyfriend Marcus will be among them, but even he doesn’t know the secrets she keeps hidden behind a veil of lies. None of them really know her, and that’s only part of the problem.\",\"subject\":\"Fiction\",\"imageURL\":\"https://images-na.ssl-images-amazon.com/images/I/51SLlJ5SWOL.jpg\",\"quantity\":10,\"borrowCount\":0,\"favCount\":0,\"upvotes\":0,\"downvotes\":1,\"createdAt\":\"2018-05-10T03:11:52.181Z\",\"updatedAt\":\"2018-06-23T19:05:19.889Z\"}}}"
+            },
+            "x-testShouldPass": true,
+            "x-testEnabled": true,
+            "x-testName": "Downvote a book",
+            "x-testDescription": "Endpoint to downvote a book in the application"
+          }
+        ],
+        "x-operation-settings": {
+          "CollectParameters": false,
+          "AllowDynamicQueryParameters": false,
+          "AllowDynamicFormParameters": false,
+          "IsMultiContentStreaming": false
+        }
+      }
+    },
+    "/users/{userId}": {
+      "get": {
+        "description": "Endpoint for an authenticated users to retrieve their profile",
+        "summary": "Get a user's profile",
+        "operationId": "Users4Get",
+        "tags": [
+          "Users"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [{
+          "name": "userId",
+          "in": "path",
+          "required": true,
+          "type": "integer"
+        }],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/GetAUser'sProfileresponse"
+            },
+            "examples": {
+              "application/json": {
+                "message": "Successful",
+                "user": {
+                  "id": 3,
+                  "firstName": "Grace",
+                  "lastName": "Jade",
+                  "email": "gracejade@gmail.com",
+                  "role": "User",
+                  "imageURL": "null",
+                  "createdAt": "\"2018-06-23T14:42:46.827Z\"",
+                  "updatedAt": "\"2018-06-23T14:42:46.827Z\"",
+                  "userBooks": [
+                    {
+                      "id": 4,
+                      "status": "Returned",
+                      "createdAt": "\"2018-06-24T01:06:38.794Z\"",
+                      "updatedAt": "\"2018-06-24T01:20:19.257Z\"",
+                      "userId": 3,
+                      "bookId": 99,
+                      "borrowedBooks": {
+                        "title": "Lies That Bind Us",
+                        "author": "Andrew Hart"
+                      }
+                    }
+                  ],
+                  "userBorrowRequests": [
+                    {
+                      "id": 5,
+                      "reason": "Research",
+                      "comments": "Nil",
+                      "returnDate": "\"2018-12-07T23:00:00Z\"",
+                      "status": "Accepted",
+                      "createdAt": "\"2018-06-24T00:52:46.37Z\"",
+                      "updatedAt": "\"2018-06-24T01:06:38.789Z\"",
+                      "userId": 3,
+                      "bookId": 99,
+                      "borrowRequests": {
+                        "title": "Lies That Bind Us",
+                        "author": "Andrew Hart"
+                      }
+                    }
+                  ],
+                  "userReturnRequests": [
+                    {
+                      "id": 4,
+                      "comments": "null",
+                      "status": "Accepted",
+                      "createdAt": "\"2018-06-24T01:14:32.115Z\"",
+                      "updatedAt": "\"2018-06-24T01:20:19.244Z\"",
+                      "userId": 3,
+                      "bookId": 99,
+                      "returnRequests": {
+                        "title": "Lies That Bind Us",
+                        "author": "Andrew Hart"
+                      }
+                    }
+                  ],
+                  "userFavorites": [
+                    {
+                      "id": 2,
+                      "createdAt": "\"2018-06-23T19:14:10.907Z\"",
+                      "updatedAt": "\"2018-06-23T19:14:10.907Z\"",
+                      "userId": 3,
+                      "bookId": 99,
+                      "favBook": {
+                        "title": "Lies That Bind Us",
+                        "author": "Andrew Hart"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "schema": {
+              "$ref": "#/definitions/GetAUser'sProfileerrorresponse"
+            },
+            "examples": {
+              "application/json": {
+                "message": "Unsuccessful",
+                "error": "You are not authorized to perform this action"
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "userToken": []
+          }
+        ],
+        "x-unitTests": [
+          {
+            "request": {
+              "method": "GET",
+              "uri": "/users/4"
+            },
+            "expectedResponse": {
+              "x-allowExtraHeaders": true,
+              "x-bodyMatchMode": "RAW",
+              "x-arrayOrderedMatching": false,
+              "x-arrayCheckCount": false,
+              "x-matchResponseSchema": true,
+              "headers": {
+                "Connection": "keep-alive",
+                "Content-Length": "1159",
+                "Content-Type": "application/json; charset=utf-8",
+                "Date": "Sun, 24 Jun 2018 01:28:11 GMT",
+                "ETag": "W/\"487-A5Lst5FDyjyBXz0XbRLtC9STCsM\"",
+                "X-Powered-By": "Express"
+              },
+              "body": "{\"message\":\"Successful\",\"user\":{\"id\":3,\"firstName\":\"Grace\",\"lastName\":\"Jade\",\"email\":\"gracejade@gmail.com\",\"role\":\"User\",\"imageURL\":\"null\",\"createdAt\":\"\\\"2018-06-23T14:42:46.827Z\\\"\",\"updatedAt\":\"\\\"2018-06-23T14:42:46.827Z\\\"\",\"userBooks\":[{\"id\":4,\"status\":\"Returned\",\"createdAt\":\"\\\"2018-06-24T01:06:38.794Z\\\"\",\"updatedAt\":\"\\\"2018-06-24T01:20:19.257Z\\\"\",\"userId\":3,\"bookId\":99,\"borrowedBooks\":{\"title\":\"Lies That Bind Us\",\"author\":\"Andrew Hart\"}}],\"userBorrowRequests\":[{\"id\":5,\"reason\":\"Research\",\"comments\":\"Nil\",\"returnDate\":\"\\\"2018-12-07T23:00:00Z\\\"\",\"status\":\"Accepted\",\"createdAt\":\"\\\"2018-06-24T00:52:46.37Z\\\"\",\"updatedAt\":\"\\\"2018-06-24T01:06:38.789Z\\\"\",\"userId\":3,\"bookId\":99,\"borrowRequests\":{\"title\":\"Lies That Bind Us\",\"author\":\"Andrew Hart\"}}],\"userReturnRequests\":[{\"id\":4,\"comments\":\"null\",\"status\":\"Accepted\",\"createdAt\":\"\\\"2018-06-24T01:14:32.115Z\\\"\",\"updatedAt\":\"\\\"2018-06-24T01:20:19.244Z\\\"\",\"userId\":3,\"bookId\":99,\"returnRequests\":{\"title\":\"Lies That Bind Us\",\"author\":\"Andrew Hart\"}}],\"userFavorites\":[{\"id\":2,\"createdAt\":\"\\\"2018-06-23T19:14:10.907Z\\\"\",\"updatedAt\":\"\\\"2018-06-23T19:14:10.907Z\\\"\",\"userId\":3,\"bookId\":99,\"favBook\":{\"title\":\"Lies That Bind Us\",\"author\":\"Andrew Hart\"}}]}}"
+            },
+            "x-testShouldPass": true,
+            "x-testEnabled": true,
+            "x-testName": "Get a user's profile",
+            "x-testDescription": "Endpoint for an authenticated users to retrieve their profile"
+          }
+        ],
+        "x-operation-settings": {
+          "CollectParameters": false,
+          "AllowDynamicQueryParameters": false,
+          "AllowDynamicFormParameters": false,
+          "IsMultiContentStreaming": false
+        }
+      }
+    },
+    "/users/{userId}/favbooks": {
+      "get": {
+        "description": "Endpoint to get the books a user has added to favorites",
+        "summary": "Get a user's favorite books",
+        "operationId": "Users1000FavbooksGet",
+        "tags": [
+          "Users"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [{
+          "name": "userId",
+          "in": "path",
+          "required": true,
+          "type": "integer"
+        }],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/GetAUser'sFavoriteBooksresponse"
+            },
+            "examples": {
+              "application/json": {
+                "message": "Successful",
+                "favorites": [
+                  {
+                    "id": 2,
+                    "createdAt": "2018-06-23T19:14:10.907Z",
+                    "updatedAt": "2018-06-23T19:14:10.907Z",
+                    "userId": 3,
+                    "bookId": 99,
+                    "favBook": {
+                      "id": 99,
+                      "title": "Lies That Bind Us",
+                      "author": "Andrew Hart",
+                      "description": "Jan needs this. She’s flying to Crete to reunite with friends she met there five years ago and relive an idyllic vacation. Basking in the warmth of the sun, the azure sea, and the aura of antiquity, she can once again pretend—for a little while—that she belongs. Her ex-boyfriend Marcus will be among them, but even he doesn’t know the secrets she keeps hidden behind a veil of lies. None of them really know her, and that’s only part of the problem.",
+                      "subject": "Fiction",
+                      "imageURL": "https://images-na.ssl-images-amazon.com/images/I/51SLlJ5SWOL.jpg",
+                      "quantity": 10,
+                      "borrowCount": 0,
+                      "favCount": 1,
+                      "upvotes": 0,
+                      "downvotes": 1,
+                      "createdAt": "2018-05-10T03:11:52.181Z",
+                      "updatedAt": "2018-06-23T19:14:10.925Z"
+                    }
+                  }
+                ],
+                "pagination": {
+                  "pageCount": 1,
+                  "pageSize": 1,
+                  "currentPage": 1,
+                  "bookCount": 1
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Similar to 403 Forbidden, but specifically for use when authentication is possible but has failed or not yet been provided. The response must include a WWW-Authenticate header field containing a challenge applicable to the requested resource.",
+            "schema": {
+              "$ref": "#/definitions/GetAUser'sFavoriteBookserrorresponse"
+            },
+            "examples": {
+              "application/json": {
+                "message": "Unsuccessful",
+                "error": "No token provided"
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "schema": {
+              "$ref": "#/definitions/GetAUser'sFavoriteBookserrorresponse"
+            },
+            "examples": {
+              "application/json": {
+                "message": "Unsuccessful",
+                "error": "You are not authorized to perform this action"
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "userToken": []
+          }
+        ],
+        "x-unitTests": [
+          {
+            "request": {
+              "method": "GET",
+              "uri": "/users/-1000/favbooks"
+            },
+            "expectedResponse": {
+              "x-allowExtraHeaders": true,
+              "x-bodyMatchMode": "RAW",
+              "x-arrayOrderedMatching": false,
+              "x-arrayCheckCount": false,
+              "x-matchResponseSchema": true,
+              "headers": {
+                "Connection": "keep-alive",
+                "Content-Length": "1013",
+                "Content-Type": "application/json; charset=utf-8",
+                "Date": "Sat, 23 Jun 2018 19:23:50 GMT",
+                "ETag": "W/\"3f5-auOwkakbkAx5BMzKlr4fYRJ3oRc\"",
+                "X-Powered-By": "Express"
+              },
+              "body": "{\"message\":\"Successful\",\"favorites\":[{\"id\":2,\"createdAt\":\"2018-06-23T19:14:10.907Z\",\"updatedAt\":\"2018-06-23T19:14:10.907Z\",\"userId\":3,\"bookId\":99,\"favBook\":{\"id\":99,\"title\":\"Lies That Bind Us\",\"author\":\"Andrew Hart\",\"description\":\"Jan needs this. She’s flying to Crete to reunite with friends she met there five years ago and relive an idyllic vacation. Basking in the warmth of the sun, the azure sea, and the aura of antiquity, she can once again pretend—for a little while—that she belongs. Her ex-boyfriend Marcus will be among them, but even he doesn’t know the secrets she keeps hidden behind a veil of lies. None of them really know her, and that’s only part of the problem.\",\"subject\":\"Fiction\",\"imageURL\":\"https://images-na.ssl-images-amazon.com/images/I/51SLlJ5SWOL.jpg\",\"quantity\":10,\"borrowCount\":0,\"favCount\":1,\"upvotes\":0,\"downvotes\":1,\"createdAt\":\"2018-05-10T03:11:52.181Z\",\"updatedAt\":\"2018-06-23T19:14:10.925Z\"}}],\"pagination\":{\"pageCount\":1,\"pageSize\":1,\"currentPage\":1,\"bookCount\":1}}"
+            },
+            "x-testShouldPass": true,
+            "x-testEnabled": true,
+            "x-testName": "Get a user's favorite books",
+            "x-testDescription": "Endpoint to get the books a user has added to favorites"
+          }
+        ],
+        "x-operation-settings": {
+          "CollectParameters": false,
+          "AllowDynamicQueryParameters": false,
+          "AllowDynamicFormParameters": false,
+          "IsMultiContentStreaming": false
+        }
+      }
+    }
+  },
+  "definitions": {
+    "UpvoteABookresponse": {
+      "title": "Upvote a book Response",
+      "example": {
+        "message": "Successful",
+        "vote": {
+          "bookId": "4",
+          "book": {
+            "id": 4,
+            "title": "A new book",
+            "author": "An updated author",
+            "description": "A book on romance",
+            "subject": "Romance",
+            "imageURL": "https://res.cloudinary.com/ama-hello-books-v2/image/upload/v1529657777/Lean_In__book_cr3jst.jpg",
+            "quantity": 11,
+            "borrowCount": 0,
+            "favCount": 0,
+            "upvotes": 1,
+            "downvotes": 0,
+            "createdAt": "2018-06-23T18:18:17.17Z",
+            "updatedAt": "2018-06-23T18:57:04.307Z"
+          }
+        }
+      },
+      "type": "object",
+      "properties": {
+        "message": {
+          "description": "",
+          "example": "Successful",
+          "type": "string"
+        },
+        "vote": {
+          "$ref": "#/definitions/Vote"
+        }
+      },
+      "required": [
+        "message",
+        "vote"
+      ]
+    },
+    "Vote": {
+      "title": "Vote",
+      "example": {
+        "bookId": "4",
+        "book": {
+          "id": 4,
+          "title": "A new book",
+          "author": "An updated author",
+          "description": "A book on romance",
+          "subject": "Romance",
+          "imageURL": "https://res.cloudinary.com/ama-hello-books-v2/image/upload/v1529657777/Lean_In__book_cr3jst.jpg",
+          "quantity": 11,
+          "borrowCount": 0,
+          "favCount": 0,
+          "upvotes": 1,
+          "downvotes": 0,
+          "createdAt": "2018-06-23T18:18:17.17Z",
+          "updatedAt": "2018-06-23T18:57:04.307Z"
+        }
+      },
+      "type": "object",
+      "properties": {
+        "bookId": {
+          "description": "",
+          "example": "4",
+          "type": "string"
+        },
+        "book": {
+          "$ref": "#/definitions/Book"
+        }
+      },
+      "required": [
+        "bookId",
+        "book"
+      ]
+    },
+    "Book": {
+      "title": "Book",
+      "example": {
+        "id": 4,
+        "title": "A new book",
+        "author": "An updated author",
+        "description": "A book on romance",
+        "subject": "Romance",
+        "imageURL": "https://res.cloudinary.com/ama-hello-books-v2/image/upload/v1529657777/Lean_In__book_cr3jst.jpg",
+        "quantity": 11,
+        "borrowCount": 0,
+        "favCount": 0,
+        "upvotes": 1,
+        "downvotes": 0,
+        "createdAt": "2018-06-23T18:18:17.17Z",
+        "updatedAt": "2018-06-23T18:57:04.307Z"
+      },
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "",
+          "example": 4,
+          "type": "integer",
+          "format": "int32"
+        },
+        "title": {
+          "description": "",
+          "example": "A new book",
+          "type": "string"
+        },
+        "author": {
+          "description": "",
+          "example": "An updated author",
+          "type": "string"
+        },
+        "description": {
+          "description": "",
+          "example": "A book on romance",
+          "type": "string"
+        },
+        "subject": {
+          "description": "",
+          "example": "Romance",
+          "type": "string"
+        },
+        "imageURL": {
+          "description": "",
+          "example": "https://res.cloudinary.com/ama-hello-books-v2/image/upload/v1529657777/Lean_In__book_cr3jst.jpg",
+          "type": "string"
+        },
+        "quantity": {
+          "description": "",
+          "example": 11,
+          "type": "integer",
+          "format": "int32"
+        },
+        "borrowCount": {
+          "description": "",
+          "example": 0,
+          "type": "integer",
+          "format": "int32"
+        },
+        "favCount": {
+          "description": "",
+          "example": 0,
+          "type": "integer",
+          "format": "int32"
+        },
+        "upvotes": {
+          "description": "",
+          "example": 1,
+          "type": "integer",
+          "format": "int32"
+        },
+        "downvotes": {
+          "description": "",
+          "example": 0,
+          "type": "integer",
+          "format": "int32"
+        },
+        "createdAt": {
+          "description": "",
+          "example": "6/23/2018 6:18:17 PM",
+          "type": "string"
+        },
+        "updatedAt": {
+          "description": "",
+          "example": "6/23/2018 6:57:04 PM",
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "title",
+        "author",
+        "description",
+        "subject",
+        "imageURL",
+        "quantity",
+        "borrowCount",
+        "favCount",
+        "upvotes",
+        "downvotes",
+        "createdAt",
+        "updatedAt"
+      ]
+    },
+    "UpvoteABookerrorresponse": {
+      "title": "Upvote a book ErrorResponse",
+      "example": {
+        "message": "Unsuccessful",
+        "error": "ValidationError: child \"params\" fails because [child \"bookId\" fails because [\"bookId\" must be a positive number]]"
+      },
+      "type": "object",
+      "properties": {
+        "message": {
+          "description": "",
+          "example": "Unsuccessful",
+          "type": "string"
+        },
+        "error": {
+          "description": "",
+          "example": "ValidationError: child \"params\" fails because [child \"bookId\" fails because [\"bookId\" must be a positive number]]",
+          "type": "string"
+        }
+      },
+      "required": [
+        "message",
+        "error"
+      ]
+    },
+    "Accept/rejectARequestToBorrowABookrequest": {
+      "title": "Accept/reject a request to borrow a book Request",
+      "example": {
+        "status": "Declined"
+      },
+      "type": "object",
+      "properties": {
+        "status": {
+          "description": "",
+          "example": "Declined",
+          "type": "string"
+        }
+      },
+      "required": [
+        "status"
+      ]
+    },
+    "Accept/rejectARequestToBorrowABookerrorresponse": {
+      "title": "Accept/reject a request to borrow a book ErrorResponse",
+      "example": {
+        "message": "Unsuccessful",
+        "error": "ValidationError: child \"body\" fails because [child \"status\" fails because [\"status\" must be one of [Declined, Accepted]]]"
+      },
+      "type": "object",
+      "properties": {
+        "message": {
+          "description": "",
+          "example": "Unsuccessful",
+          "type": "string"
+        },
+        "error": {
+          "description": "",
+          "example": "Borrow request not found",
+          "type": "string"
+        }
+      },
+      "required": [
+        "message",
+        "error"
+      ]
+    },
+    "Accept/rejectARequestToBorrowABookresponse": {
+      "title": "Accept/reject a request to borrow a book Response",
+      "example": {
+        "message": "Successful",
+        "borrowRequest": {
+          "id": 6,
+          "reason": "Research",
+          "comments": "Nil",
+          "returnDate": "2018-12-07T23:00:00Z",
+          "status": "Accepted",
+          "createdAt": "2018-06-24T13:27:59.303Z",
+          "updatedAt": "2018-06-24T13:34:31.161Z",
+          "userId": 6,
+          "bookId": 99
+        }
+      },
+      "type": "object",
+      "properties": {
+        "message": {
+          "description": "",
+          "example": "Successful",
+          "type": "string"
+        },
+        "borrowRequest": {
+          "$ref": "#/definitions/BorrowRequest"
+        }
+      },
+      "required": [
+        "message",
+        "borrowRequest"
+      ]
+    },
+    "BorrowRequest": {
+      "title": "BorrowRequest",
+      "example": {
+        "id": 6,
+        "reason": "Research",
+        "comments": "Nil",
+        "returnDate": "2018-12-07T23:00:00Z",
+        "status": "Accepted",
+        "createdAt": "2018-06-24T13:27:59.303Z",
+        "updatedAt": "2018-06-24T13:34:31.161Z",
+        "userId": 6,
+        "bookId": 99
+      },
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "",
+          "example": 6,
+          "type": "integer",
+          "format": "int32"
+        },
+        "reason": {
+          "description": "",
+          "example": "Research",
+          "type": "string"
+        },
+        "comments": {
+          "description": "",
+          "example": "Nil",
+          "type": "string"
+        },
+        "returnDate": {
+          "description": "",
+          "example": "12/7/2018 11:00:00 PM",
+          "type": "string"
+        },
+        "status": {
+          "description": "",
+          "example": "Accepted",
+          "type": "string"
+        },
+        "createdAt": {
+          "description": "",
+          "example": "6/24/2018 1:27:59 PM",
+          "type": "string"
+        },
+        "updatedAt": {
+          "description": "",
+          "example": "6/24/2018 1:34:31 PM",
+          "type": "string"
+        },
+        "userId": {
+          "description": "",
+          "example": 6,
+          "type": "integer",
+          "format": "int32"
+        },
+        "bookId": {
+          "description": "",
+          "example": 99,
+          "type": "integer",
+          "format": "int32"
+        }
+      },
+      "required": [
+        "id",
+        "reason",
+        "comments",
+        "returnDate",
+        "status",
+        "createdAt",
+        "updatedAt",
+        "userId",
+        "bookId"
+      ]
+    },
+    "GetAllBooksresponse": {
+      "title": "Get all books Response",
+      "example": {
+        "message": "Successful",
+        "books": [
+          {
+            "id": 1,
+            "title": "Lean In",
+            "author": "Sheryl Sandberg",
+            "description": "A guide on how women can balance career and family",
+            "subject": "Self-help",
+            "imageURL": "https://res.cloudinary.com/ama-hello-books-v2/image/upload/v1529657777/Lean_In__book_cr3jst.jpg",
+            "quantity": 20,
+            "borrowCount": 0,
+            "favCount": 0,
+            "upvotes": 1,
+            "downvotes": 0,
+            "createdAt": "2018-06-22T08:56:20.614Z",
+            "updatedAt": "2018-06-22T12:22:28.308Z",
+            "bookReviews": []
+          },
+          {
+            "id": 96,
+            "title": "Love and Ruin",
+            "author": "Paul McClain",
+            "description": "Magnolia Table is infused with Joanna Gaines' warmth and passion for all things family, prepared and served straight from the heart of her home, with recipes inspired by dozens of Gaines family favorites and classic comfort selections from the couple's new Waco restaurant, Magnolia Table",
+            "subject": "Romance",
+            "imageURL": "https://images-na.ssl-images-amazon.com/images/I/51keKmj6MSL._SX327_BO1,204,203,200_.jpg",
+            "quantity": 20,
+            "borrowCount": 1,
+            "favCount": 0,
+            "upvotes": 1,
+            "downvotes": 0,
+            "createdAt": "2018-05-10T03:11:52.181Z",
+            "updatedAt": "2018-06-22T12:22:48.895Z",
+            "bookReviews": []
+          },
+          {
+            "id": 99,
+            "title": "Lies That Bind Us",
+            "author": "Andrew Hart",
+            "description": "Jan needs this. She’s flying to Crete to reunite with friends she met there five years ago and relive an idyllic vacation. Basking in the warmth of the sun, the azure sea, and the aura of antiquity, she can once again pretend—for a little while—that she belongs. Her ex-boyfriend Marcus will be among them, but even he doesn’t know the secrets she keeps hidden behind a veil of lies. None of them really know her, and that’s only part of the problem.",
+            "subject": "Fiction",
+            "imageURL": "https://images-na.ssl-images-amazon.com/images/I/51SLlJ5SWOL.jpg",
+            "quantity": 10,
+            "borrowCount": 0,
+            "favCount": 0,
+            "upvotes": 0,
+            "downvotes": 0,
+            "createdAt": "2018-05-10T03:11:52.181Z",
+            "updatedAt": "2018-05-10T03:11:52.181Z",
+            "bookReviews": []
+          },
+          {
+            "id": 94,
+            "title": "Macbeth",
+            "author": "A.J.Hartley",
+            "description": "Macbeth: A Novel brings the intricacy and grit of the historical thriller to Shakespeare's tale of political intrigue, treachery, and murder.",
+            "subject": "Romance",
+            "imageURL": "https://images-na.ssl-images-amazon.com/images/I/51l6MwpodJL._AA300_.jpg",
+            "quantity": 70,
+            "borrowCount": 0,
+            "favCount": 0,
+            "upvotes": 0,
+            "downvotes": 0,
+            "createdAt": "2018-05-10T03:11:52.181Z",
+            "updatedAt": "2018-05-10T03:11:52.181Z",
+            "bookReviews": []
+          },
+          {
+            "id": 98,
+            "title": "I\"ll Be Gone in the Dark",
+            "author": "Michelle McNamara",
+            "description": "A masterful true crime account of the Golden State Killer - the elusive serial rapist turned murderer who terrorized California for over a decade - from Michelle McNamara, the gifted journalist who died tragically while investigating the case.",
+            "subject": "True Crime",
+            "imageURL": "https://images-na.ssl-images-amazon.com/images/I/616zw9dVVxL._AA300_.jpg",
+            "quantity": 5,
+            "borrowCount": 1,
+            "favCount": 0,
+            "upvotes": 0,
+            "downvotes": 0,
+            "createdAt": "2018-05-10T03:11:52.181Z",
+            "updatedAt": "2018-06-21T21:11:19.059Z",
+            "bookReviews": []
+          },
+          {
+            "id": 97,
+            "title": "Magnolia Table: A Collection of Recipes for Gathering",
+            "author": "Joanna Gaines",
+            "description": "Magnolia Table is infused with Joanna Gaines' warmth and passion for all things family, prepared and served straight from the heart of her home, with recipes inspired by dozens of Gaines family favorites and classic comfort selections from the couple's new Waco restaurant, Magnolia Table",
+            "subject": "Recipe",
+            "imageURL": "https://images-na.ssl-images-amazon.com/images/I/51ciUK5JaCL._SX376_BO1,204,203,200_.jpg",
+            "quantity": 7,
+            "borrowCount": 0,
+            "favCount": 0,
+            "upvotes": 0,
+            "downvotes": 0,
+            "createdAt": "2018-05-10T03:11:52.181Z",
+            "updatedAt": "2018-05-10T03:11:52.181Z",
+            "bookReviews": []
+          },
+          {
+            "id": 90,
+            "title": "Matchmaking for Beginners",
+            "author": "Maddie Dawson",
+            "description": "Marnie MacGraw wants an ordinary life—a husband, kids, and a minivan in the suburbs. Now that she’s marrying the man of her dreams, she’s sure this is the life she’ll get. Then Marnie meets Blix Holliday, her fiancé’s irascible matchmaking great-aunt who’s dying, and everything changes—just as Blix told her it would.",
+            "subject": "Romance",
+            "imageURL": "https://images-na.ssl-images-amazon.com/images/I/61TbLNxP6rL.jpg",
+            "quantity": 10,
+            "borrowCount": 0,
+            "favCount": 0,
+            "upvotes": 0,
+            "downvotes": 0,
+            "createdAt": "2018-05-10T03:11:52.181Z",
+            "updatedAt": "2018-05-10T03:11:52.181Z",
+            "bookReviews": []
+          },
+          {
+            "id": 92,
+            "title": "A Place Called Freedom",
+            "author": "Ken Follet",
+            "description": "This lush novel, set in 1766 England and America, evokes an era ripe with riot and revolution, from the teeming streets of London to the sprawling grounds of a Virginia plantation.",
+            "subject": "Thriller",
+            "imageURL": "https://images-na.ssl-images-amazon.com/images/I/51tXUJPsi7L._AA300_.jpg",
+            "quantity": 2,
+            "borrowCount": 0,
+            "favCount": 0,
+            "upvotes": 0,
+            "downvotes": 0,
+            "createdAt": "2018-05-10T03:11:52.181Z",
+            "updatedAt": "2018-05-10T03:11:52.181Z",
+            "bookReviews": []
+          },
+          {
+            "id": 95,
+            "title": "Born a Crime",
+            "author": "Trevor Noah",
+            "description": "Attuned to the power of language at a young age - as a means of acceptance and influence in a country divided, then subdivided, into groups at odds with one another - Noah's raw, personal journey becomes something extraordinary in audio: a true testament to the power of storytelling",
+            "subject": "Biography",
+            "imageURL": "https://images-na.ssl-images-amazon.com/images/I/61mJhMWAq8L._AA300_.jpg",
+            "quantity": 20,
+            "borrowCount": 0,
+            "favCount": 0,
+            "upvotes": 0,
+            "downvotes": 0,
+            "createdAt": "2018-05-10T03:11:52.181Z",
+            "updatedAt": "2018-05-10T03:11:52.181Z",
+            "bookReviews": []
+          }
+        ],
+        "pagination": {
+          "pageCount": 2,
+          "pageSize": 9,
+          "currentPage": 1,
+          "bookCount": 11
+        }
+      },
+      "type": "object",
+      "properties": {
+        "message": {
+          "description": "",
+          "example": "Successful",
+          "type": "string"
+        },
+        "books": {
+          "description": "",
+          "example": [
+            {
+              "id": 1,
+              "title": "Lean In",
+              "author": "Sheryl Sandberg",
+              "description": "A guide on how women can balance career and family",
+              "subject": "Self-help",
+              "imageURL": "https://res.cloudinary.com/ama-hello-books-v2/image/upload/v1529657777/Lean_In__book_cr3jst.jpg",
+              "quantity": 20,
+              "borrowCount": 0,
+              "favCount": 0,
+              "upvotes": 1,
+              "downvotes": 0,
+              "createdAt": "2018-06-22T08:56:20.614Z",
+              "updatedAt": "2018-06-22T12:22:28.308Z",
+              "bookReviews": []
+            },
+            {
+              "id": 96,
+              "title": "Love and Ruin",
+              "author": "Paul McClain",
+              "description": "Magnolia Table is infused with Joanna Gaines' warmth and passion for all things family, prepared and served straight from the heart of her home, with recipes inspired by dozens of Gaines family favorites and classic comfort selections from the couple's new Waco restaurant, Magnolia Table",
+              "subject": "Romance",
+              "imageURL": "https://images-na.ssl-images-amazon.com/images/I/51keKmj6MSL._SX327_BO1,204,203,200_.jpg",
+              "quantity": 20,
+              "borrowCount": 1,
+              "favCount": 0,
+              "upvotes": 1,
+              "downvotes": 0,
+              "createdAt": "2018-05-10T03:11:52.181Z",
+              "updatedAt": "2018-06-22T12:22:48.895Z",
+              "bookReviews": []
+            },
+            {
+              "id": 99,
+              "title": "Lies That Bind Us",
+              "author": "Andrew Hart",
+              "description": "Jan needs this. She’s flying to Crete to reunite with friends she met there five years ago and relive an idyllic vacation. Basking in the warmth of the sun, the azure sea, and the aura of antiquity, she can once again pretend—for a little while—that she belongs. Her ex-boyfriend Marcus will be among them, but even he doesn’t know the secrets she keeps hidden behind a veil of lies. None of them really know her, and that’s only part of the problem.",
+              "subject": "Fiction",
+              "imageURL": "https://images-na.ssl-images-amazon.com/images/I/51SLlJ5SWOL.jpg",
+              "quantity": 10,
+              "borrowCount": 0,
+              "favCount": 0,
+              "upvotes": 0,
+              "downvotes": 0,
+              "createdAt": "2018-05-10T03:11:52.181Z",
+              "updatedAt": "2018-05-10T03:11:52.181Z",
+              "bookReviews": []
+            },
+            {
+              "id": 94,
+              "title": "Macbeth",
+              "author": "A.J.Hartley",
+              "description": "Macbeth: A Novel brings the intricacy and grit of the historical thriller to Shakespeare's tale of political intrigue, treachery, and murder.",
+              "subject": "Romance",
+              "imageURL": "https://images-na.ssl-images-amazon.com/images/I/51l6MwpodJL._AA300_.jpg",
+              "quantity": 70,
+              "borrowCount": 0,
+              "favCount": 0,
+              "upvotes": 0,
+              "downvotes": 0,
+              "createdAt": "2018-05-10T03:11:52.181Z",
+              "updatedAt": "2018-05-10T03:11:52.181Z",
+              "bookReviews": []
+            },
+            {
+              "id": 98,
+              "title": "I\"ll Be Gone in the Dark",
+              "author": "Michelle McNamara",
+              "description": "A masterful true crime account of the Golden State Killer - the elusive serial rapist turned murderer who terrorized California for over a decade - from Michelle McNamara, the gifted journalist who died tragically while investigating the case.",
+              "subject": "True Crime",
+              "imageURL": "https://images-na.ssl-images-amazon.com/images/I/616zw9dVVxL._AA300_.jpg",
+              "quantity": 5,
+              "borrowCount": 1,
+              "favCount": 0,
+              "upvotes": 0,
+              "downvotes": 0,
+              "createdAt": "2018-05-10T03:11:52.181Z",
+              "updatedAt": "2018-06-21T21:11:19.059Z",
+              "bookReviews": []
+            },
+            {
+              "id": 97,
+              "title": "Magnolia Table: A Collection of Recipes for Gathering",
+              "author": "Joanna Gaines",
+              "description": "Magnolia Table is infused with Joanna Gaines' warmth and passion for all things family, prepared and served straight from the heart of her home, with recipes inspired by dozens of Gaines family favorites and classic comfort selections from the couple's new Waco restaurant, Magnolia Table",
+              "subject": "Recipe",
+              "imageURL": "https://images-na.ssl-images-amazon.com/images/I/51ciUK5JaCL._SX376_BO1,204,203,200_.jpg",
+              "quantity": 7,
+              "borrowCount": 0,
+              "favCount": 0,
+              "upvotes": 0,
+              "downvotes": 0,
+              "createdAt": "2018-05-10T03:11:52.181Z",
+              "updatedAt": "2018-05-10T03:11:52.181Z",
+              "bookReviews": []
+            },
+            {
+              "id": 90,
+              "title": "Matchmaking for Beginners",
+              "author": "Maddie Dawson",
+              "description": "Marnie MacGraw wants an ordinary life—a husband, kids, and a minivan in the suburbs. Now that she’s marrying the man of her dreams, she’s sure this is the life she’ll get. Then Marnie meets Blix Holliday, her fiancé’s irascible matchmaking great-aunt who’s dying, and everything changes—just as Blix told her it would.",
+              "subject": "Romance",
+              "imageURL": "https://images-na.ssl-images-amazon.com/images/I/61TbLNxP6rL.jpg",
+              "quantity": 10,
+              "borrowCount": 0,
+              "favCount": 0,
+              "upvotes": 0,
+              "downvotes": 0,
+              "createdAt": "2018-05-10T03:11:52.181Z",
+              "updatedAt": "2018-05-10T03:11:52.181Z",
+              "bookReviews": []
+            },
+            {
+              "id": 92,
+              "title": "A Place Called Freedom",
+              "author": "Ken Follet",
+              "description": "This lush novel, set in 1766 England and America, evokes an era ripe with riot and revolution, from the teeming streets of London to the sprawling grounds of a Virginia plantation.",
+              "subject": "Thriller",
+              "imageURL": "https://images-na.ssl-images-amazon.com/images/I/51tXUJPsi7L._AA300_.jpg",
+              "quantity": 2,
+              "borrowCount": 0,
+              "favCount": 0,
+              "upvotes": 0,
+              "downvotes": 0,
+              "createdAt": "2018-05-10T03:11:52.181Z",
+              "updatedAt": "2018-05-10T03:11:52.181Z",
+              "bookReviews": []
+            },
+            {
+              "id": 95,
+              "title": "Born a Crime",
+              "author": "Trevor Noah",
+              "description": "Attuned to the power of language at a young age - as a means of acceptance and influence in a country divided, then subdivided, into groups at odds with one another - Noah's raw, personal journey becomes something extraordinary in audio: a true testament to the power of storytelling",
+              "subject": "Biography",
+              "imageURL": "https://images-na.ssl-images-amazon.com/images/I/61mJhMWAq8L._AA300_.jpg",
+              "quantity": 20,
+              "borrowCount": 0,
+              "favCount": 0,
+              "upvotes": 0,
+              "downvotes": 0,
+              "createdAt": "2018-05-10T03:11:52.181Z",
+              "updatedAt": "2018-05-10T03:11:52.181Z",
+              "bookReviews": []
+            }
+          ],
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Book15"
+          }
+        },
+        "pagination": {
+          "$ref": "#/definitions/Pagination"
+        }
+      },
+      "required": [
+        "message",
+        "books",
+        "pagination"
+      ]
+    },
+    "Book15": {
+      "title": "Book15",
+      "example": {
+        "id": 1,
+        "title": "Lean In",
+        "author": "Sheryl Sandberg",
+        "description": "A guide on how women can balance career and family",
+        "subject": "Self-help",
+        "imageURL": "https://res.cloudinary.com/ama-hello-books-v2/image/upload/v1529657777/Lean_In__book_cr3jst.jpg",
+        "quantity": 20,
+        "borrowCount": 0,
+        "favCount": 0,
+        "upvotes": 1,
+        "downvotes": 0,
+        "createdAt": "2018-06-22T08:56:20.614Z",
+        "updatedAt": "2018-06-22T12:22:28.308Z",
+        "bookReviews": []
+      },
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "",
+          "example": 1,
+          "type": "integer",
+          "format": "int32"
+        },
+        "title": {
+          "description": "",
+          "example": "Lean In",
+          "type": "string"
+        },
+        "author": {
+          "description": "",
+          "example": "Sheryl Sandberg",
+          "type": "string"
+        },
+        "description": {
+          "description": "",
+          "example": "A guide on how women can balance career and family",
+          "type": "string"
+        },
+        "subject": {
+          "description": "",
+          "example": "Self-help",
+          "type": "string"
+        },
+        "imageURL": {
+          "description": "",
+          "example": "https://res.cloudinary.com/ama-hello-books-v2/image/upload/v1529657777/Lean_In__book_cr3jst.jpg",
+          "type": "string"
+        },
+        "quantity": {
+          "description": "",
+          "example": 20,
+          "type": "integer",
+          "format": "int32"
+        },
+        "borrowCount": {
+          "description": "",
+          "example": 0,
+          "type": "integer",
+          "format": "int32"
+        },
+        "favCount": {
+          "description": "",
+          "example": 0,
+          "type": "integer",
+          "format": "int32"
+        },
+        "upvotes": {
+          "description": "",
+          "example": 1,
+          "type": "integer",
+          "format": "int32"
+        },
+        "downvotes": {
+          "description": "",
+          "example": 0,
+          "type": "integer",
+          "format": "int32"
+        },
+        "createdAt": {
+          "description": "",
+          "example": "6/22/2018 8:56:20 AM",
+          "type": "string"
+        },
+        "updatedAt": {
+          "description": "",
+          "example": "6/22/2018 12:22:28 PM",
+          "type": "string"
+        },
+        "bookReviews": {
+          "description": "",
+          "example": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "id",
+        "title",
+        "author",
+        "description",
+        "subject",
+        "imageURL",
+        "quantity",
+        "borrowCount",
+        "favCount",
+        "upvotes",
+        "downvotes",
+        "createdAt",
+        "updatedAt",
+        "bookReviews"
+      ]
+    },
+    "Pagination": {
+      "title": "Pagination",
+      "example": {
+        "pageCount": 2,
+        "pageSize": 9,
+        "currentPage": 1,
+        "bookCount": 11
+      },
+      "type": "object",
+      "properties": {
+        "pageCount": {
+          "description": "",
+          "example": 2,
+          "type": "integer",
+          "format": "int32"
+        },
+        "pageSize": {
+          "description": "",
+          "example": 9,
+          "type": "integer",
+          "format": "int32"
+        },
+        "currentPage": {
+          "description": "",
+          "example": 1,
+          "type": "integer",
+          "format": "int32"
+        },
+        "bookCount": {
+          "description": "",
+          "example": 11,
+          "type": "integer",
+          "format": "int32"
+        }
+      },
+      "required": [
+        "pageCount",
+        "pageSize",
+        "currentPage",
+        "bookCount"
+      ]
+    },
+    "SendARequestToReturnABorrowedBookerrorresponse": {
+      "title": "Send a request to return a borrowed book ErrorResponse",
+      "example": {
+        "message": "Unsuccessful",
+        "error": "ValidationError: child \"params\" fails because [child \"bookId\" fails because [\"bookId\" must be a positive number]]"
+      },
+      "type": "object",
+      "properties": {
+        "message": {
+          "description": "",
+          "example": "Unsuccessful",
+          "type": "string"
+        },
+        "error": {
+          "description": "",
+          "example": "Your request has already been sent",
+          "type": "string"
+        }
+      },
+      "required": [
+        "message",
+        "error"
+      ]
+    },
+    "SendARequestToReturnABorrowedBookresponse": {
+      "title": "Send a request to return a borrowed book Response",
+      "example": {
+        "message": "Successful",
+        "returnRequest": {
+          "id": 5,
+          "comments": "null",
+          "status": "Pending",
+          "createdAt": "\"2018-06-24T13:39:42.424Z\"",
+          "updatedAt": "\"2018-06-24T13:39:42.424Z\"",
+          "userId": 6,
+          "bookId": 99,
+          "returnRequests": {
+            "title": "New title",
+            "author": "New author"
+          }
+        }
+      },
+      "type": "object",
+      "properties": {
+        "message": {
+          "description": "",
+          "example": "Successful",
+          "type": "string"
+        },
+        "returnRequest": {
+          "$ref": "#/definitions/ReturnRequest"
+        }
+      },
+      "required": [
+        "message",
+        "returnRequest"
+      ]
+    },
+    "ReturnRequest": {
+      "title": "ReturnRequest",
+      "example": {
+        "id": 5,
+        "comments": null,
+        "status": "Pending",
+        "createdAt": "2018-06-24T13:39:42.424Z",
+        "updatedAt": "2018-06-24T13:39:42.424Z",
+        "userId": 6,
+        "bookId": 99,
+        "returnRequests": {
+          "title": "New title",
+          "author": "New author"
+        }
+      },
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "",
+          "example": 5,
+          "type": "integer",
+          "format": "int32"
+        },
+        "comments": {
+          "description": "",
+          "type": "string"
+        },
+        "status": {
+          "description": "",
+          "example": "Pending",
+          "type": "string"
+        },
+        "createdAt": {
+          "description": "",
+          "example": "6/24/2018 1:39:42 PM",
+          "type": "string"
+        },
+        "updatedAt": {
+          "description": "",
+          "example": "6/24/2018 1:39:42 PM",
+          "type": "string"
+        },
+        "userId": {
+          "description": "",
+          "example": 6,
+          "type": "integer",
+          "format": "int32"
+        },
+        "bookId": {
+          "description": "",
+          "example": 99,
+          "type": "integer",
+          "format": "int32"
+        },
+        "returnRequests": {
+          "$ref": "#/definitions/ReturnRequests"
+        }
+      },
+      "required": [
+        "id",
+        "comments",
+        "status",
+        "createdAt",
+        "updatedAt",
+        "userId",
+        "bookId",
+        "returnRequests"
+      ]
+    },
+    "ReturnRequests": {
+      "title": "ReturnRequests",
+      "example": {
+        "title": "New title",
+        "author": "New author"
+      },
+      "type": "object",
+      "properties": {
+        "title": {
+          "description": "",
+          "example": "New title",
+          "type": "string"
+        },
+        "author": {
+          "description": "",
+          "example": "New author",
+          "type": "string"
+        }
+      },
+      "required": [
+        "title",
+        "author"
+      ]
+    },
+    "GetBooksresponse": {
+      "title": "Get books",
+      "example": {
+        "message": "Successful",
+        "books": [
+          {
+            "id": 96,
+            "title": "Love and Ruin",
+            "author": "Paul McClain",
+            "description": "Magnolia Table is infused with Joanna Gaines' warmth and passion for all things family, prepared and served straight from the heart of her home, with recipes inspired by dozens of Gaines family favorites and classic comfort selections from the couple's new Waco restaurant, Magnolia Table",
+            "subject": "Romance",
+            "imageURL": "https://images-na.ssl-images-amazon.com/images/I/51keKmj6MSL._SX327_BO1,204,203,200_.jpg",
+            "quantity": 20,
+            "borrowCount": 1,
+            "favCount": 0,
+            "upvotes": 1,
+            "downvotes": 0,
+            "createdAt": "2018-05-10T03:11:52.181Z",
+            "updatedAt": "2018-06-22T12:22:48.895Z",
+            "bookReviews": []
+          },
+          {
+            "id": 1,
+            "title": "Lean In",
+            "author": "Sheryl Sandberg",
+            "description": "A guide on how women can balance career and family",
+            "subject": "Self-help",
+            "imageURL": "https://res.cloudinary.com/ama-hello-books-v2/image/upload/v1529657777/Lean_In__book_cr3jst.jpg",
+            "quantity": 20,
+            "borrowCount": 0,
+            "favCount": 0,
+            "upvotes": 1,
+            "downvotes": 0,
+            "createdAt": "2018-06-22T08:56:20.614Z",
+            "updatedAt": "2018-06-22T12:22:28.308Z",
+            "bookReviews": []
+          }
+        ],
+        "pagination": {
+          "pageCount": 1,
+          "pageSize": 2,
+          "currentPage": 1,
+          "bookCount": 2
+        }
+      },
+      "type": "object",
+      "properties": {
+        "message": {
+          "example": "Successful",
+          "type": "string"
+        },
+        "books": {
+          "example": [
+            {
+              "id": 96,
+              "title": "Love and Ruin",
+              "author": "Paul McClain",
+              "description": "Magnolia Table is infused with Joanna Gaines' warmth and passion for all things family, prepared and served straight from the heart of her home, with recipes inspired by dozens of Gaines family favorites and classic comfort selections from the couple's new Waco restaurant, Magnolia Table",
+              "subject": "Romance",
+              "imageURL": "https://images-na.ssl-images-amazon.com/images/I/51keKmj6MSL._SX327_BO1,204,203,200_.jpg",
+              "quantity": 20,
+              "borrowCount": 1,
+              "favCount": 0,
+              "upvotes": 1,
+              "downvotes": 0,
+              "createdAt": "2018-05-10T03:11:52.181Z",
+              "updatedAt": "2018-06-22T12:22:48.895Z",
+              "bookReviews": []
+            },
+            {
+              "id": 1,
+              "title": "Lean In",
+              "author": "Sheryl Sandberg",
+              "description": "A guide on how women can balance career and family",
+              "subject": "Self-help",
+              "imageURL": "https://res.cloudinary.com/ama-hello-books-v2/image/upload/v1529657777/Lean_In__book_cr3jst.jpg",
+              "quantity": 20,
+              "borrowCount": 0,
+              "favCount": 0,
+              "upvotes": 1,
+              "downvotes": 0,
+              "createdAt": "2018-06-22T08:56:20.614Z",
+              "updatedAt": "2018-06-22T12:22:28.308Z",
+              "bookReviews": []
+            }
+          ],
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Book15"
+          }
+        },
+        "pagination": {
+          "$ref": "#/definitions/Pagination"
+        }
+      },
+      "required": [
+        "message",
+        "books",
+        "pagination"
+      ]
+    },
+    "GetABookerrorresponse": {
+      "title": "Get a book ErrorResponse",
+      "example": {
+        "message": "Unsuccessful",
+        "error": "ValidationError: child \"params\" fails because [child \"bookId\" fails because [\"bookId\" must be a positive number]]"
+      },
+      "type": "object",
+      "properties": {
+        "message": {
+          "description": "",
+          "example": "Unsuccessful",
+          "type": "string"
+        },
+        "error": {
+          "description": "",
+          "example": "ValidationError: child \"params\" fails because [child \"bookId\" fails because [\"bookId\" must be a positive number]]",
+          "type": "string"
+        }
+      },
+      "required": [
+        "message",
+        "error"
+      ]
+    },
+    "GetABookresponse": {
+      "title": "Get a book Response",
+      "example": {
+        "message": "Successful",
+        "book": {
+          "id": 1,
+          "title": "Lean In",
+          "author": "Sheryl Sandberg",
+          "description": "A guide on how women can balance career and family",
+          "subject": "Self-help",
+          "imageURL": "https://res.cloudinary.com/ama-hello-books-v2/image/upload/v1529657777/Lean_In__book_cr3jst.jpg",
+          "quantity": 20,
+          "borrowCount": 0,
+          "favCount": 0,
+          "upvotes": 1,
+          "downvotes": 0,
+          "createdAt": "2018-06-22T08:56:20.614Z",
+          "updatedAt": "2018-06-22T12:22:28.308Z",
+          "bookReviews": []
+        }
+      },
+      "type": "object",
+      "properties": {
+        "message": {
+          "description": "",
+          "example": "Successful",
+          "type": "string"
+        },
+        "book": {
+          "$ref": "#/definitions/Book15"
+        }
+      },
+      "required": [
+        "message",
+        "book"
+      ]
+    },
+    "AddABookrequest": {
+      "title": "Add a book Request",
+      "example": {
+        "title": "A new book",
+        "author": "Stephen Covey",
+        "description": "Dr. Covey's 7 Habits book is one of the most inspiring and impactful books ever written. Now you can enjoy and learn critical lessons about the habits of successful people that will enrich your life's experience",
+        "quantity": 20,
+        "subject": "Inspiration",
+        "imageURL": "https://images-na.ssl-images-amazon.com/images/I/51ciUK5JaCL._SX376_BO1,204,203,200_.jpg"
+      },
+      "type": "object",
+      "properties": {
+        "title": {
+          "example": "A new book",
+          "type": "string"
+        },
+        "author": {
+          "example": "Stephen Covey",
+          "type": "string"
+        },
+        "description": {
+          "example": "Dr. Covey's 7 Habits book is one of the most inspiring and impactful books ever written. Now you can enjoy and learn critical lessons about the habits of successful people that will enrich your life's experience",
+          "type": "string"
+        },
+        "quantity": {
+          "example": 20,
+          "type": "integer",
+          "format": "int32"
+        },
+        "subject": {
+          "description": "",
+          "example": "Inspiration",
+          "type": "string"
+        },
+        "imageURL": {
+          "example": "https://images-na.ssl-images-amazon.com/images/I/51fEYMhtHoL.jpg",
+          "type": "string"
+        }
+      },
+      "required": [
+        "title",
+        "author",
+        "description",
+        "quantity",
+        "subject",
+        "imageURL"
+      ]
+    },
+    "AddABookerrorresponse": {
+      "title": "Add a book ErrorResponse",
+      "example": {
+        "message": "Unsuccessful",
+        "error": "ValidationError: child \"imageURL\" fails because [\"imageURL\" is required]"
+      },
+      "type": "object",
+      "properties": {
+        "message": {
+          "description": "",
+          "example": "Unsuccessful",
+          "type": "string"
+        },
+        "error": {
+          "description": "",
+          "example": "A book with this title already exists. Input a different title",
+          "type": "string"
+        }
+      },
+      "required": [
+        "message",
+        "error"
+      ]
+    },
+    "AddABookresponse": {
+      "title": "Add a book Response",
+      "example": {
+        "message": "Successful",
+        "bookEntry": {
+          "borrowCount": 0,
+          "favCount": 0,
+          "upvotes": 0,
+          "downvotes": 0,
+          "id": 5,
+          "title": "A new book",
+          "author": "Stephen Covey",
+          "description": "Dr. Covey's 7 Habits book is one of the most inspiring and impactful books ever written. Now you can enjoy and learn critical lessons about the habits of successful people that will enrich your life's experience",
+          "subject": "Inspiration",
+          "imageURL": "https://images-na.ssl-images-amazon.com/images/I/51fEYMhtHoL.jpg",
+          "quantity": 20,
+          "updatedAt": "2018-06-24T12:59:07.573Z",
+          "createdAt": "2018-06-24T12:59:07.573Z"
+        }
+      },
+      "type": "object",
+      "properties": {
+        "message": {
+          "description": "",
+          "example": "Successful",
+          "type": "string"
+        },
+        "bookEntry": {
+          "$ref": "#/definitions/BookEntry"
+        }
+      },
+      "required": [
+        "message",
+        "bookEntry"
+      ]
+    },
+    "BookEntry": {
+      "title": "BookEntry",
+      "example": {
+        "borrowCount": 0,
+        "favCount": 0,
+        "upvotes": 0,
+        "downvotes": 0,
+        "id": 5,
+        "title": "A new book",
+        "author": "Stephen Covey",
+        "description": "Dr. Covey's 7 Habits book is one of the most inspiring and impactful books ever written. Now you can enjoy and learn critical lessons about the habits of successful people that will enrich your life's experience",
+        "subject": "Inspiration",
+        "imageURL": "https://images-na.ssl-images-amazon.com/images/I/51fEYMhtHoL.jpg",
+        "quantity": 20,
+        "updatedAt": "2018-06-24T12:59:07.573Z",
+        "createdAt": "2018-06-24T12:59:07.573Z"
+      },
+      "type": "object",
+      "properties": {
+        "borrowCount": {
+          "example": 0,
+          "type": "integer",
+          "format": "int32"
+        },
+        "favCount": {
+          "example": 0,
+          "type": "integer",
+          "format": "int32"
+        },
+        "upvotes": {
+          "example": 0,
+          "type": "integer",
+          "format": "int32"
+        },
+        "downvotes": {
+          "example": 0,
+          "type": "integer",
+          "format": "int32"
+        },
+        "id": {
+          "example": 5,
+          "type": "integer",
+          "format": "int32"
+        },
+        "title": {
+          "example": "A new book",
+          "type": "string"
+        },
+        "author": {
+          "example": "Stephen Covey",
+          "type": "string"
+        },
+        "description": {
+          "example": "Dr. Covey's 7 Habits book is one of the most inspiring and impactful books ever written. Now you can enjoy and learn critical lessons about the habits of successful people that will enrich your life's experience",
+          "type": "string"
+        },
+        "subject": {
+          "example": "Inspiration",
+          "type": "string"
+        },
+        "imageURL": {
+          "example": "https://images-na.ssl-images-amazon.com/images/I/51fEYMhtHoL.jpg",
+          "type": "string"
+        },
+        "quantity": {
+          "example": 20,
+          "type": "integer",
+          "format": "int32"
+        },
+        "updatedAt": {
+          "example": "6/24/2018 12:59:07 PM",
+          "type": "string"
+        },
+        "createdAt": {
+          "example": "6/24/2018 12:59:07 PM",
+          "type": "string"
+        }
+      },
+      "required": [
+        "borrowCount",
+        "favCount",
+        "upvotes",
+        "downvotes",
+        "id",
+        "title",
+        "author",
+        "description",
+        "subject",
+        "imageURL",
+        "quantity",
+        "updatedAt",
+        "createdAt"
+      ]
+    },
+    "UsersSignuprequest": {
+      "title": "Users signup Request",
+      "example": {
+        "firstName": "Amarachi",
+        "lastName": "Agbo",
+        "email": "amarachukwu.agbo@andela.com",
+        "password": "password"
+      },
+      "type": "object",
+      "properties": {
+        "firstName": {
+          "description": "",
+          "example": "Amarachi",
+          "type": "string"
+        },
+        "lastName": {
+          "description": "",
+          "example": "Agbo",
+          "type": "string"
+        },
+        "email": {
+          "description": "",
+          "example": "amarachukwu.agbo@andela.com",
+          "type": "string"
+        },
+        "password": {
+          "description": "",
+          "example": "password",
+          "type": "string"
+        }
+      },
+      "required": [
+        "firstName",
+        "lastName",
+        "email",
+        "password"
+      ]
+    },
+    "UsersSignuperrorresponse": {
+      "title": "Users signup ErrorResponse",
+      "example": {
+        "message": "Unsuccessful",
+        "error": "ValidationError: child \"email\" fails because [\"email\" must be a valid email]"
+      },
+      "type": "object",
+      "properties": {
+        "message": {
+          "example": "Unsuccessful",
+          "type": "string"
+        },
+        "error": {
+          "example": "ValidationError: child \"email\" fails because [\"email\" must be a valid email]",
+          "type": "string"
+        }
+      },
+      "required": [
+        "message",
+        "error"
+      ]
+    },
+    "UsersSignupresponse": {
+      "title": "Users signup Response",
+      "example": {
+        "message": "Successful",
+        "user": {
+          "id": 6,
+          "firstName": "Amarachi",
+          "role": "User"
+        },
+        "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6NiwiaWF0IjoxNTI5ODQ0MDE1LCJleHAiOjE1Mjk5MzA0MTV9.3easojr1WjPEjlg7_OHvFbb0i8LN_iwch8TBnEkhZ14"
+      },
+      "type": "object",
+      "properties": {
+        "message": {
+          "example": "Successful",
+          "type": "string"
+        },
+        "user": {
+          "$ref": "#/definitions/User"
+        },
+        "token": {
+          "example": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6NiwiaWF0IjoxNTI5ODQ0MDE1LCJleHAiOjE1Mjk5MzA0MTV9.3easojr1WjPEjlg7_OHvFbb0i8LN_iwch8TBnEkhZ14",
+          "type": "string"
+        }
+      },
+      "required": [
+        "message",
+        "user",
+        "token"
+      ]
+    },
+    "User": {
+      "title": "User",
+      "example": {
+        "id": 6,
+        "firstName": "Amarachi",
+        "role": "User"
+      },
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "",
+          "example": 6,
+          "type": "integer",
+          "format": "int32"
+        },
+        "firstName": {
+          "description": "",
+          "example": "Amarachi",
+          "type": "string"
+        },
+        "role": {
+          "description": "",
+          "example": "User",
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "firstName",
+        "role"
+      ]
+    },
+    "SearchForABookInTheDatabaseerrorresponse": {
+      "title": "Search for a book in the database ErrorResponse",
+      "example": {
+        "message": "Unsuccessful",
+        "error": "ValidationError: child \"query\" fails because [\"name\" is not allowed]"
+      },
+      "type": "object",
+      "properties": {
+        "message": {
+          "example": "Unsuccessful",
+          "type": "string"
+        },
+        "error": {
+          "example": "ValidationError: child \"query\" fails because [\"name\" is not allowed]",
+          "type": "string"
+        }
+      },
+      "required": [
+        "message",
+        "error"
+      ]
+    },
+    "SearchForABookInTheDatabaseresponse": {
+      "title": "Search for a book in the database Response",
+      "example": {
+        "message": "Successful",
+        "books": [
+          {
+            "id": 94,
+            "title": "Macbeth",
+            "author": "A.J.Hartley",
+            "description": "Macbeth: A Novel brings the intricacy and grit of the historical thriller to Shakespeare's tale of political intrigue, treachery, and murder.",
+            "subject": "Romance",
+            "imageURL": "https://images-na.ssl-images-amazon.com/images/I/51l6MwpodJL._AA300_.jpg",
+            "quantity": 70,
+            "borrowCount": 0,
+            "favCount": 0,
+            "upvotes": 0,
+            "downvotes": 0,
+            "createdAt": "2018-05-10T03:11:52.181Z",
+            "updatedAt": "2018-05-10T03:11:52.181Z",
+            "bookReviews": []
+          }
+        ],
+        "pagination": {
+          "pageCount": 1,
+          "pageSize": 1,
+          "currentPage": 1,
+          "bookCount": 1
+        }
+      },
+      "type": "object",
+      "properties": {
+        "message": {
+          "description": "",
+          "example": "Successful",
+          "type": "string"
+        },
+        "books": {
+          "example": [
+            {
+              "id": 94,
+              "title": "Macbeth",
+              "author": "A.J.Hartley",
+              "description": "Macbeth: A Novel brings the intricacy and grit of the historical thriller to Shakespeare's tale of political intrigue, treachery, and murder.",
+              "subject": "Romance",
+              "imageURL": "https://images-na.ssl-images-amazon.com/images/I/51l6MwpodJL._AA300_.jpg",
+              "quantity": 70,
+              "borrowCount": 0,
+              "favCount": 0,
+              "upvotes": 0,
+              "downvotes": 0,
+              "createdAt": "2018-05-10T03:11:52.181Z",
+              "updatedAt": "2018-05-10T03:11:52.181Z",
+              "bookReviews": []
+            }
+          ],
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Book15"
+          }
+        },
+        "pagination": {
+          "$ref": "#/definitions/Pagination"
+        }
+      },
+      "required": [
+        "message",
+        "books",
+        "pagination"
+      ]
+    },
+    "MakeARequestToBorrowABookrequest": {
+      "title": "Make a request to borrow a book Request",
+      "example": {
+        "returnDate": "12/12/2018",
+        "reason": "Research",
+        "comments": "Nil"
+      },
+      "type": "object",
+      "properties": {
+        "reason": {
+          "example": "Research",
+          "type": "string"
+        },
+        "returnDate": {
+          "example": "12/12/2018",
+          "type": "string"
+        },
+        "comments": {
+          "example": "Nil",
+          "type": "string"
+        }
+      },
+      "required": [
+        "returnDate",
+        "reason"
+      ]
+    },
+    "MakeARequestToBorrowABookresponse": {
+      "title": "Make a request to borrow a book Response",
+      "example": {
+        "message": "Successful",
+        "request": {
+          "status": "Pending",
+          "id": 6,
+          "bookId": 99,
+          "userId": 6,
+          "reason": "Research",
+          "returnDate": "2018-12-07T23:00:00Z",
+          "comments": "Nil",
+          "updatedAt": "2018-06-24T13:27:59.303Z",
+          "createdAt": "2018-06-24T13:27:59.303Z"
+        }
+      },
+      "type": "object",
+      "properties": {
+        "message": {
+          "example": "Successful",
+          "type": "string"
+        },
+        "request": {
+          "$ref": "#/definitions/Request"
+        }
+      },
+      "required": [
+        "message",
+        "request"
+      ]
+    },
+    "Request": {
+      "title": "Request",
+      "example": {
+        "status": "Pending",
+        "id": 6,
+        "bookId": 99,
+        "userId": 6,
+        "reason": "Research",
+        "returnDate": "2018-12-07T23:00:00Z",
+        "comments": "Nil",
+        "updatedAt": "2018-06-24T13:27:59.303Z",
+        "createdAt": "2018-06-24T13:27:59.303Z"
+      },
+      "type": "object",
+      "properties": {
+        "status": {
+          "example": "Pending",
+          "type": "string"
+        },
+        "id": {
+          "example": 6,
+          "type": "integer",
+          "format": "int32"
+        },
+        "bookId": {
+          "example": 99,
+          "type": "integer",
+          "format": "int32"
+        },
+        "userId": {
+          "example": 6,
+          "type": "integer",
+          "format": "int32"
+        },
+        "reason": {
+          "example": "Research",
+          "type": "string"
+        },
+        "returnDate": {
+          "example": "12/7/2018 11:00:00 PM",
+          "type": "string"
+        },
+        "comments": {
+          "example": "Nil",
+          "type": "string"
+        },
+        "updatedAt": {
+          "example": "6/24/2018 1:27:59 PM",
+          "type": "string"
+        },
+        "createdAt": {
+          "example": "6/24/2018 1:27:59 PM",
+          "type": "string"
+        }
+      },
+      "required": [
+        "status",
+        "id",
+        "bookId",
+        "userId",
+        "reason",
+        "returnDate",
+        "comments",
+        "updatedAt",
+        "createdAt"
+      ]
+    },
+    "MakeARequestToBorrowABookerrorresponse": {
+      "title": "Make a request to borrow a book ErrorResponse",
+      "example": {
+        "message": "Unsuccessful",
+        "error": "ValidationError: child \"params\" fails because [child \"bookId\" fails because [\"bookId\" must be a positive number]]"
+      },
+      "type": "object",
+      "properties": {
+        "message": {
+          "example": "Unsuccessful",
+          "type": "string"
+        },
+        "error": {
+          "example": "ValidationError: child \"params\" fails because [child \"bookId\" fails because [\"bookId\" must be a positive number]]",
+          "type": "string"
+        }
+      },
+      "required": [
+        "message",
+        "error"
+      ]
+    },
+    "MarkABookAsFavoriteerrorresponse": {
+      "title": "Mark a book as favorite ErrorResponse",
+      "example": {
+        "message": "Unsuccessful",
+        "error": "ValidationError: child \"params\" fails because [child \"bookId\" fails because [\"bookId\" must be a positive number]]"
+      },
+      "type": "object",
+      "properties": {
+        "message": {
+          "example": "Unsuccessful",
+          "type": "string"
+        },
+        "error": {
+          "example": "Book was not found",
+          "type": "string"
+        }
+      },
+      "required": [
+        "message",
+        "error"
+      ]
+    },
+    "MarkABookAsFavoriteresponse": {
+      "title": "Mark a book as favorite Response",
+      "example": {
+        "message": "Successful",
+        "favorite": {
+          "id": 2,
+          "bookId": 99,
+          "userId": 3,
+          "updatedAt": "2018-06-23T19:14:10.907Z",
+          "createdAt": "2018-06-23T19:14:10.907Z"
+        },
+        "book": {
+          "id": 99,
+          "title": "Lies That Bind Us",
+          "author": "Andrew Hart",
+          "description": "Jan needs this. She’s flying to Crete to reunite with friends she met there five years ago and relive an idyllic vacation. Basking in the warmth of the sun, the azure sea, and the aura of antiquity, she can once again pretend—for a little while—that she belongs. Her ex-boyfriend Marcus will be among them, but even he doesn’t know the secrets she keeps hidden behind a veil of lies. None of them really know her, and that’s only part of the problem.",
+          "subject": "Fiction",
+          "imageURL": "https://images-na.ssl-images-amazon.com/images/I/51SLlJ5SWOL.jpg",
+          "quantity": 10,
+          "borrowCount": 0,
+          "favCount": 1,
+          "upvotes": 0,
+          "downvotes": 1,
+          "createdAt": "2018-05-10T03:11:52.181Z",
+          "updatedAt": "2018-06-23T19:14:10.925Z"
+        }
+      },
+      "type": "object",
+      "properties": {
+        "message": {
+          "example": "Successful",
+          "type": "string"
+        },
+        "favorite": {
+          "$ref": "#/definitions/Favorite"
+        },
+        "book": {
+          "$ref": "#/definitions/Book"
+        }
+      },
+      "required": [
+        "message",
+        "favorite",
+        "book"
+      ]
+    },
+    "Favorite": {
+      "title": "Favorite",
+      "example": {
+        "id": 2,
+        "bookId": 99,
+        "userId": 3,
+        "updatedAt": "2018-06-23T19:14:10.907Z",
+        "createdAt": "2018-06-23T19:14:10.907Z"
+      },
+      "type": "object",
+      "properties": {
+        "id": {
+          "example": 2,
+          "type": "integer",
+          "format": "int32"
+        },
+        "bookId": {
+          "example": 99,
+          "type": "integer",
+          "format": "int32"
+        },
+        "userId": {
+          "example": 3,
+          "type": "integer",
+          "format": "int32"
+        },
+        "updatedAt": {
+          "example": "6/23/2018 7:14:10 PM",
+          "type": "string"
+        },
+        "createdAt": {
+          "example": "6/23/2018 7:14:10 PM",
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "bookId",
+        "userId",
+        "updatedAt",
+        "createdAt"
+      ]
+    },
+    "Accept/rejectARequestByAUserToReturnABookrequest": {
+      "title": "Accept/reject a request by a user to return a book Request",
+      "example": {
+        "status": "Accepted"
+      },
+      "type": "object",
+      "properties": {
+        "status": {
+          "example": "Accepted",
+          "type": "string"
+        }
+      },
+      "required": [
+        "status"
+      ]
+    },
+    "Accept/rejectARequestByAUserToReturnABookresponse": {
+      "title": "Accept/reject a request by a user to return a book Response",
+      "example": {
+        "message": "Successful",
+        "returnRequest": {
+          "id": 5,
+          "status": "Returned",
+          "createdAt": "2018-06-24T13:34:31.172Z",
+          "updatedAt": "2018-06-24T13:46:22.856Z",
+          "userId": 6,
+          "bookId": 99
+        }
+      },
+      "type": "object",
+      "properties": {
+        "message": {
+          "example": "Successful",
+          "type": "string"
+        },
+        "returnRequest": {
+          "$ref": "#/definitions/ReturnRequest66"
+        }
+      },
+      "required": [
+        "message",
+        "returnRequest"
+      ]
+    },
+    "ReturnRequest66": {
+      "title": "ReturnRequest66",
+      "example": {
+        "id": 5,
+        "status": "Returned",
+        "createdAt": "2018-06-24T13:34:31.172Z",
+        "updatedAt": "2018-06-24T13:46:22.856Z",
+        "userId": 6,
+        "bookId": 99
+      },
+      "type": "object",
+      "properties": {
+        "id": {
+          "example": 5,
+          "type": "integer",
+          "format": "int32"
+        },
+        "status": {
+          "example": "Returned",
+          "type": "string"
+        },
+        "createdAt": {
+          "example": "6/24/2018 1:34:31 PM",
+          "type": "string"
+        },
+        "updatedAt": {
+          "example": "6/24/2018 1:46:22 PM",
+          "type": "string"
+        },
+        "userId": {
+          "example": 6,
+          "type": "integer",
+          "format": "int32"
+        },
+        "bookId": {
+          "example": 99,
+          "type": "integer",
+          "format": "int32"
+        }
+      },
+      "required": [
+        "id",
+        "status",
+        "createdAt",
+        "updatedAt",
+        "userId",
+        "bookId"
+      ]
+    },
+    "Accept/rejectARequestByAUserToReturnABookerrorresponse": {
+      "title": "Accept/reject a request by a user to return a book ErrorResponse",
+      "example": {
+        "message": "Unsuccessful",
+        "error": "No token provided"
+      },
+      "type": "object",
+      "properties": {
+        "message": {
+          "example": "Unsuccessful",
+          "type": "string"
+        },
+        "error": {
+          "example": "You must be an admin to access this feature",
+          "type": "string"
+        }
+      },
+      "required": [
+        "message",
+        "error"
+      ]
+    },
+    "DeleteABookerrorresponse": {
+      "title": "Delete  a book ErrorResponse",
+      "example": {
+        "message": "Unsuccessful",
+        "error": "bookId must be a positive integer"
+      },
+      "type": "object",
+      "properties": {
+        "message": {
+          "example": "Unsuccessful",
+          "type": "string"
+        },
+        "error": {
+          "example": "Book was not found",
+          "type": "string"
+        }
+      },
+      "required": [
+        "message",
+        "error"
+      ]
+    },
+    "ReviewABookrequest": {
+      "title": "Review a book Request",
+      "example": {
+        "review": ""
+      },
+      "type": "object",
+      "properties": {
+        "review": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "review"
+      ]
+    },
+    "ReviewABookerrorresponse": {
+      "title": "Review a book ErrorResponse",
+      "example": {
+        "message": "Unsuccessful",
+        "error": "ValidationError: child \"params\" fails because [child \"bookId\" fails because [\"bookId\" must be a positive number]]"
+      },
+      "type": "object",
+      "properties": {
+        "message": {
+          "example": "Unsuccessful",
+          "type": "string"
+        },
+        "error": {
+          "example": "No token provided",
+          "type": "string"
+        }
+      },
+      "required": [
+        "message",
+        "error"
+      ]
+    },
+    "ReviewABookresponse": {
+      "title": "Review a bookResponse",
+      "example": {
+        "message": "Successful",
+        "reviewedBook": {
+          "id": 1,
+          "title": "Lean In",
+          "author": "Sheryl Sandberg",
+          "description": "A guide on how women can balance career and family",
+          "subject": "Self-help",
+          "imageURL": "https://res.cloudinary.com/ama-hello-books-v2/image/upload/v1529657777/Lean_In__book_cr3jst.jpg",
+          "quantity": 20,
+          "borrowCount": 0,
+          "favCount": 0,
+          "upvotes": 1,
+          "downvotes": 0,
+          "createdAt": "\"2018-06-22T08:56:20.614Z\"",
+          "updatedAt": "\"2018-06-22T12:22:28.308Z\"",
+          "bookReviews": [
+            {
+              "id": 2,
+              "review": "I enjoyed reading this book",
+              "createdAt": "\"2018-06-24T13:18:52.295Z\"",
+              "updatedAt": "\"2018-06-24T13:18:52.295Z\"",
+              "userId": 3,
+              "bookId": 1,
+              "userReviews": {
+                "id": 3,
+                "firstName": "Grace",
+                "lastName": "Jade",
+                "imageURL": "null",
+                "createdAt": "\"2018-06-23T14:42:46.827Z\""
+              }
+            }
+          ]
+        }
+      },
+      "type": "object",
+      "properties": {
+        "message": {
+          "example": "Successful",
+          "type": "string"
+        },
+        "reviewedBook": {
+          "$ref": "#/definitions/ReviewedBook"
+        }
+      },
+      "required": [
+        "message",
+        "reviewedBook"
+      ]
+    },
+    "ReviewedBook": {
+      "title": "ReviewedBook",
+      "example": {
+        "id": 1,
+        "title": "Lean In",
+        "author": "Sheryl Sandberg",
+        "description": "A guide on how women can balance career and family",
+        "subject": "Self-help",
+        "imageURL": "https://res.cloudinary.com/ama-hello-books-v2/image/upload/v1529657777/Lean_In__book_cr3jst.jpg",
+        "quantity": 20,
+        "borrowCount": 0,
+        "favCount": 0,
+        "upvotes": 1,
+        "downvotes": 0,
+        "createdAt": "\"2018-06-22T08:56:20.614Z\"",
+        "updatedAt": "\"2018-06-22T12:22:28.308Z\"",
+        "bookReviews": [
+          {
+            "id": 2,
+            "review": "I enjoyed reading this book",
+            "createdAt": "\"2018-06-24T13:18:52.295Z\"",
+            "updatedAt": "\"2018-06-24T13:18:52.295Z\"",
+            "userId": 3,
+            "bookId": 1,
+            "userReviews": {
+              "id": 3,
+              "firstName": "Grace",
+              "lastName": "Jade",
+              "imageURL": "null",
+              "createdAt": "\"2018-06-23T14:42:46.827Z\""
+            }
+          }
+        ]
+      },
+      "type": "object",
+      "properties": {
+        "id": {
+          "example": 1,
+          "type": "integer",
+          "format": "int32"
+        },
+        "title": {
+          "example": "Lean In",
+          "type": "string"
+        },
+        "author": {
+          "example": "Sheryl Sandberg",
+          "type": "string"
+        },
+        "description": {
+          "example": "A guide on how women can balance career and family",
+          "type": "string"
+        },
+        "subject": {
+          "example": "Self-help",
+          "type": "string"
+        },
+        "imageURL": {
+          "example": "https://res.cloudinary.com/ama-hello-books-v2/image/upload/v1529657777/Lean_In__book_cr3jst.jpg",
+          "type": "string"
+        },
+        "quantity": {
+          "example": 20,
+          "type": "integer",
+          "format": "int32"
+        },
+        "borrowCount": {
+          "description": "",
+          "example": 0,
+          "type": "integer",
+          "format": "int32"
+        },
+        "favCount": {
+          "example": 0,
+          "type": "integer",
+          "format": "int32"
+        },
+        "upvotes": {
+          "example": 1,
+          "type": "integer",
+          "format": "int32"
+        },
+        "downvotes": {
+          "example": 0,
+          "type": "integer",
+          "format": "int32"
+        },
+        "createdAt": {
+          "example": "6/22/2018 8:56:20 AM",
+          "type": "string"
+        },
+        "updatedAt": {
+          "example": "6/22/2018 12:22:28 PM",
+          "type": "string"
+        },
+        "bookReviews": {
+          "example": [
+            {
+              "id": 2,
+              "review": "I enjoyed reading this book",
+              "createdAt": "\"2018-06-24T13:18:52.295Z\"",
+              "updatedAt": "\"2018-06-24T13:18:52.295Z\"",
+              "userId": 3,
+              "bookId": 1,
+              "userReviews": {
+                "id": 3,
+                "firstName": "Grace",
+                "lastName": "Jade",
+                "imageURL": "null",
+                "createdAt": "\"2018-06-23T14:42:46.827Z\""
+              }
+            }
+          ],
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/BookReview"
+          }
+        }
+      },
+      "required": [
+        "id",
+        "title",
+        "author",
+        "description",
+        "subject",
+        "imageURL",
+        "quantity",
+        "borrowCount",
+        "favCount",
+        "upvotes",
+        "downvotes",
+        "createdAt",
+        "updatedAt",
+        "bookReviews"
+      ]
+    },
+    "BookReview": {
+      "title": "BookReview",
+      "example": {
+        "id": 2,
+        "review": "I enjoyed reading this book",
+        "createdAt": "\"2018-06-24T13:18:52.295Z\"",
+        "updatedAt": "\"2018-06-24T13:18:52.295Z\"",
+        "userId": 3,
+        "bookId": 1,
+        "userReviews": {
+          "id": 3,
+          "firstName": "Grace",
+          "lastName": "Jade",
+          "imageURL": "null",
+          "createdAt": "\"2018-06-23T14:42:46.827Z\""
+        }
+      },
+      "type": "object",
+      "properties": {
+        "id": {
+          "example": 2,
+          "type": "integer",
+          "format": "int32"
+        },
+        "review": {
+          "example": "I enjoyed reading this book",
+          "type": "string"
+        },
+        "createdAt": {
+          "example": "6/24/2018 1:18:52 PM",
+          "type": "string"
+        },
+        "updatedAt": {
+          "example": "6/24/2018 1:18:52 PM",
+          "type": "string"
+        },
+        "userId": {
+          "example": 3,
+          "type": "integer",
+          "format": "int32"
+        },
+        "bookId": {
+          "example": 1,
+          "type": "integer",
+          "format": "int32"
+        },
+        "userReviews": {
+          "$ref": "#/definitions/UserReviews"
+        }
+      },
+      "required": [
+        "id",
+        "review",
+        "createdAt",
+        "updatedAt",
+        "userId",
+        "bookId",
+        "userReviews"
+      ]
+    },
+    "UserReviews": {
+      "title": "UserReviews",
+      "example": {
+        "id": 3,
+        "firstName": "Grace",
+        "lastName": "Jade",
+        "imageURL": null,
+        "createdAt": "2018-06-23T14:42:46.827Z"
+      },
+      "type": "object",
+      "properties": {
+        "id": {
+          "example": 3,
+          "type": "integer",
+          "format": "int32"
+        },
+        "firstName": {
+          "example": "Grace",
+          "type": "string"
+        },
+        "lastName": {
+          "example": "Jade",
+          "type": "string"
+        },
+        "imageURL": {
+          "type": "string"
+        },
+        "createdAt": {
+          "example": "6/23/2018 2:42:46 PM",
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "firstName",
+        "lastName",
+        "imageURL",
+        "createdAt"
+      ]
+    },
+    "UsersLoginrequest": {
+      "title": "Users Login Request",
+      "example": {
+        "email": "amarachi@gmail.com",
+        "password": "password"
+      },
+      "type": "object",
+      "properties": {
+        "email": {
+          "example": "amarachi@gmail.com",
+          "type": "string"
+        },
+        "password": {
+          "example": "password",
+          "type": "string"
+        }
+      },
+      "required": [
+        "email",
+        "password"
+      ]
+    },
+    "UsersLoginerrorresponse": {
+      "title": "Users Login ErrorResponse",
+      "example": {
+        "message": "Unsuccessful",
+        "error": "ValidationError: child \"email\" fails because [\"email\" must be a valid email]"
+      },
+      "type": "object",
+      "properties": {
+        "message": {
+          "example": "Unsuccessful",
+          "type": "string"
+        },
+        "error": {
+          "example": "User not found",
+          "type": "string"
+        }
+      },
+      "required": [
+        "message",
+        "error"
+      ]
+    },
+    "UsersLoginresponse": {
+      "title": "Users Login Response",
+      "example": {
+        "message": "Successful",
+        "user": {
+          "id": 6,
+          "firstName": "Amarachi",
+          "role": "User"
+        },
+        "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6NiwiaWF0IjoxNTI5ODQ0MjkxLCJleHAiOjE1Mjk5MzA2OTF9.btGtiVDBpMOC0FGaixOLqNC2JPEEMkvNo5qBub6PVG4"
+      },
+      "type": "object",
+      "properties": {
+        "message": {
+          "example": "Successful",
+          "type": "string"
+        },
+        "user": {
+          "$ref": "#/definitions/User"
+        },
+        "token": {
+          "example": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6NiwiaWF0IjoxNTI5ODQ0MjkxLCJleHAiOjE1Mjk5MzA2OTF9.btGtiVDBpMOC0FGaixOLqNC2JPEEMkvNo5qBub6PVG4",
+          "type": "string"
+        }
+      },
+      "required": [
+        "message",
+        "user",
+        "token"
+      ]
+    },
+    "DownvoteABookerrorresponse": {
+      "title": "Downvote a book ErrorResponse",
+      "example": {
+        "message": "Unsuccessful",
+        "error": "ValidationError: child \"params\" fails because [child \"bookId\" fails because [\"bookId\" must be a positive number]]"
+      },
+      "type": "object",
+      "properties": {
+        "message": {
+          "example": "Unsuccessful",
+          "type": "string"
+        },
+        "error": {
+          "example": "ValidationError: child \"params\" fails because [child \"bookId\" fails because [\"bookId\" must be a positive number]]",
+          "type": "string"
+        }
+      },
+      "required": [
+        "message",
+        "error"
+      ]
+    },
+    "DownvoteABookresponse": {
+      "title": "Downvote a book Response",
+      "example": {
+        "message": "Successful",
+        "vote": {
+          "bookId": "99",
+          "book": {
+            "id": 99,
+            "title": "Lies That Bind Us",
+            "author": "Andrew Hart",
+            "description": "Jan needs this. She’s flying to Crete to reunite with friends she met there five years ago and relive an idyllic vacation. Basking in the warmth of the sun, the azure sea, and the aura of antiquity, she can once again pretend—for a little while—that she belongs. Her ex-boyfriend Marcus will be among them, but even he doesn’t know the secrets she keeps hidden behind a veil of lies. None of them really know her, and that’s only part of the problem.",
+            "subject": "Fiction",
+            "imageURL": "https://images-na.ssl-images-amazon.com/images/I/51SLlJ5SWOL.jpg",
+            "quantity": 10,
+            "borrowCount": 0,
+            "favCount": 0,
+            "upvotes": 0,
+            "downvotes": 1,
+            "createdAt": "2018-05-10T03:11:52.181Z",
+            "updatedAt": "2018-06-23T19:05:19.889Z"
+          }
+        }
+      },
+      "type": "object",
+      "properties": {
+        "message": {
+          "example": "Successful",
+          "type": "string"
+        },
+        "vote": {
+          "$ref": "#/definitions/Vote"
+        }
+      },
+      "required": [
+        "message",
+        "vote"
+      ]
+    },
+    "GetAUser'sProfileresponse": {
+      "title": "Get a user's profile Response",
+      "example": {
+        "message": "Successful",
+        "user": {
+          "id": 3,
+          "firstName": "Grace",
+          "lastName": "Jade",
+          "email": "gracejade@gmail.com",
+          "role": "User",
+          "imageURL": "null",
+          "createdAt": "\"2018-06-23T14:42:46.827Z\"",
+          "updatedAt": "\"2018-06-23T14:42:46.827Z\"",
+          "userBooks": [
+            {
+              "id": 4,
+              "status": "Returned",
+              "createdAt": "\"2018-06-24T01:06:38.794Z\"",
+              "updatedAt": "\"2018-06-24T01:20:19.257Z\"",
+              "userId": 3,
+              "bookId": 99,
+              "borrowedBooks": {
+                "title": "Lies That Bind Us",
+                "author": "Andrew Hart"
+              }
+            }
+          ],
+          "userBorrowRequests": [
+            {
+              "id": 5,
+              "reason": "Research",
+              "comments": "Nil",
+              "returnDate": "\"2018-12-07T23:00:00Z\"",
+              "status": "Accepted",
+              "createdAt": "\"2018-06-24T00:52:46.37Z\"",
+              "updatedAt": "\"2018-06-24T01:06:38.789Z\"",
+              "userId": 3,
+              "bookId": 99,
+              "borrowRequests": {
+                "title": "Lies That Bind Us",
+                "author": "Andrew Hart"
+              }
+            }
+          ],
+          "userReturnRequests": [
+            {
+              "id": 4,
+              "comments": "null",
+              "status": "Accepted",
+              "createdAt": "\"2018-06-24T01:14:32.115Z\"",
+              "updatedAt": "\"2018-06-24T01:20:19.244Z\"",
+              "userId": 3,
+              "bookId": 99,
+              "returnRequests": {
+                "title": "Lies That Bind Us",
+                "author": "Andrew Hart"
+              }
+            }
+          ],
+          "userFavorites": [
+            {
+              "id": 2,
+              "createdAt": "\"2018-06-23T19:14:10.907Z\"",
+              "updatedAt": "\"2018-06-23T19:14:10.907Z\"",
+              "userId": 3,
+              "bookId": 99,
+              "favBook": {
+                "title": "Lies That Bind Us",
+                "author": "Andrew Hart"
+              }
+            }
+          ]
+        }
+      },
+      "type": "object",
+      "properties": {
+        "message": {
+          "example": "Successful",
+          "type": "string"
+        },
+        "user": {
+          "$ref": "#/definitions/User98"
+        }
+      },
+      "required": [
+        "message",
+        "user"
+      ]
+    },
+    "User98": {
+      "title": "User98",
+      "example": {
+        "id": 3,
+        "firstName": "Grace",
+        "lastName": "Jade",
+        "email": "gracejade@gmail.com",
+        "role": "User",
+        "imageURL": "null",
+        "createdAt": "\"2018-06-23T14:42:46.827Z\"",
+        "updatedAt": "\"2018-06-23T14:42:46.827Z\"",
+        "userBooks": [
+          {
+            "id": 4,
+            "status": "Returned",
+            "createdAt": "\"2018-06-24T01:06:38.794Z\"",
+            "updatedAt": "\"2018-06-24T01:20:19.257Z\"",
+            "userId": 3,
+            "bookId": 99,
+            "borrowedBooks": {
+              "title": "Lies That Bind Us",
+              "author": "Andrew Hart"
+            }
+          }
+        ],
+        "userBorrowRequests": [
+          {
+            "id": 5,
+            "reason": "Research",
+            "comments": "Nil",
+            "returnDate": "\"2018-12-07T23:00:00Z\"",
+            "status": "Accepted",
+            "createdAt": "\"2018-06-24T00:52:46.37Z\"",
+            "updatedAt": "\"2018-06-24T01:06:38.789Z\"",
+            "userId": 3,
+            "bookId": 99,
+            "borrowRequests": {
+              "title": "Lies That Bind Us",
+              "author": "Andrew Hart"
+            }
+          }
+        ],
+        "userReturnRequests": [
+          {
+            "id": 4,
+            "comments": "null",
+            "status": "Accepted",
+            "createdAt": "\"2018-06-24T01:14:32.115Z\"",
+            "updatedAt": "\"2018-06-24T01:20:19.244Z\"",
+            "userId": 3,
+            "bookId": 99,
+            "returnRequests": {
+              "title": "Lies That Bind Us",
+              "author": "Andrew Hart"
+            }
+          }
+        ],
+        "userFavorites": [
+          {
+            "id": 2,
+            "createdAt": "\"2018-06-23T19:14:10.907Z\"",
+            "updatedAt": "\"2018-06-23T19:14:10.907Z\"",
+            "userId": 3,
+            "bookId": 99,
+            "favBook": {
+              "title": "Lies That Bind Us",
+              "author": "Andrew Hart"
+            }
+          }
+        ]
+      },
+      "type": "object",
+      "properties": {
+        "id": {
+          "example": 3,
+          "type": "integer",
+          "format": "int32"
+        },
+        "firstName": {
+          "example": "Grace",
+          "type": "string"
+        },
+        "lastName": {
+          "example": "Jade",
+          "type": "string"
+        },
+        "email": {
+          "example": "gracejade@gmail.com",
+          "type": "string"
+        },
+        "role": {
+          "example": "User",
+          "type": "string"
+        },
+        "imageURL": {
+          "type": "string"
+        },
+        "createdAt": {
+          "example": "6/23/2018 2:42:46 PM",
+          "type": "string"
+        },
+        "updatedAt": {
+          "example": "6/23/2018 2:42:46 PM",
+          "type": "string"
+        },
+        "userBooks": {
+          "example": [
+            {
+              "id": 4,
+              "status": "Returned",
+              "createdAt": "2018-06-24T01:06:38.794Z",
+              "updatedAt": "2018-06-24T01:20:19.257Z",
+              "userId": 3,
+              "bookId": 99,
+              "borrowedBooks": {
+                "title": "Lies That Bind Us",
+                "author": "Andrew Hart"
+              }
+            }
+          ],
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/UserBook"
+          }
+        },
+        "userBorrowRequests": {
+          "example": [
+            {
+              "id": 5,
+              "reason": "Research",
+              "comments": "Nil",
+              "returnDate": "2018-12-07T23:00:00Z",
+              "status": "Accepted",
+              "createdAt": "2018-06-24T00:52:46.37Z",
+              "updatedAt": "2018-06-24T01:06:38.789Z",
+              "userId": 3,
+              "bookId": 99,
+              "borrowRequests": {
+                "title": "Lies That Bind Us",
+                "author": "Andrew Hart"
+              }
+            }
+          ],
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/UserBorrowRequest"
+          }
+        },
+        "userReturnRequests": {
+          "example": [
+            {
+              "id": 4,
+              "comments": null,
+              "status": "Accepted",
+              "createdAt": "2018-06-24T01:14:32.115Z",
+              "updatedAt": "2018-06-24T01:20:19.244Z",
+              "userId": 3,
+              "bookId": 99,
+              "returnRequests": {
+                "title": "Lies That Bind Us",
+                "author": "Andrew Hart"
+              }
+            }
+          ],
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/UserReturnRequest"
+          }
+        },
+        "userFavorites": {
+          "example": [
+            {
+              "id": 2,
+              "createdAt": "2018-06-23T19:14:10.907Z",
+              "updatedAt": "2018-06-23T19:14:10.907Z",
+              "userId": 3,
+              "bookId": 99,
+              "favBook": {
+                "title": "Lies That Bind Us",
+                "author": "Andrew Hart"
+              }
+            }
+          ],
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/UserFavorite"
+          }
+        }
+      },
+      "required": [
+        "id",
+        "firstName",
+        "lastName",
+        "email",
+        "role",
+        "imageURL",
+        "createdAt",
+        "updatedAt",
+        "userBooks",
+        "userBorrowRequests",
+        "userReturnRequests",
+        "userFavorites"
+      ]
+    },
+    "UserBook": {
+      "title": "UserBook",
+      "example": {
+        "id": 4,
+        "status": "Returned",
+        "createdAt": "2018-06-24T01:06:38.794Z",
+        "updatedAt": "2018-06-24T01:20:19.257Z",
+        "userId": 3,
+        "bookId": 99,
+        "borrowedBooks": {
+          "title": "Lies That Bind Us",
+          "author": "Andrew Hart"
+        }
+      },
+      "type": "object",
+      "properties": {
+        "id": {
+          "example": 4,
+          "type": "integer",
+          "format": "int32"
+        },
+        "status": {
+          "example": "Returned",
+          "type": "string"
+        },
+        "createdAt": {
+          "example": "6/24/2018 1:06:38 AM",
+          "type": "string"
+        },
+        "updatedAt": {
+          "example": "6/24/2018 1:20:19 AM",
+          "type": "string"
+        },
+        "userId": {
+          "example": 3,
+          "type": "integer",
+          "format": "int32"
+        },
+        "bookId": {
+          "example": 99,
+          "type": "integer",
+          "format": "int32"
+        },
+        "borrowedBooks": {
+          "$ref": "#/definitions/BorrowedBooks"
+        }
+      },
+      "required": [
+        "id",
+        "status",
+        "createdAt",
+        "updatedAt",
+        "userId",
+        "bookId",
+        "borrowedBooks"
+      ]
+    },
+    "BorrowedBooks": {
+      "title": "BorrowedBooks",
+      "example": {
+        "title": "Lies That Bind Us",
+        "author": "Andrew Hart"
+      },
+      "type": "object",
+      "properties": {
+        "title": {
+          "example": "Lies That Bind Us",
+          "type": "string"
+        },
+        "author": {
+          "example": "Andrew Hart",
+          "type": "string"
+        }
+      },
+      "required": [
+        "title",
+        "author"
+      ]
+    },
+    "UserBorrowRequest": {
+      "title": "UserBorrowRequest",
+      "example": {
+        "id": 5,
+        "reason": "Research",
+        "comments": "Nil",
+        "returnDate": "2018-12-07T23:00:00Z",
+        "status": "Accepted",
+        "createdAt": "2018-06-24T00:52:46.37Z",
+        "updatedAt": "2018-06-24T01:06:38.789Z",
+        "userId": 3,
+        "bookId": 99,
+        "borrowRequests": {
+          "title": "Lies That Bind Us",
+          "author": "Andrew Hart"
+        }
+      },
+      "type": "object",
+      "properties": {
+        "id": {
+          "example": 5,
+          "type": "integer",
+          "format": "int32"
+        },
+        "reason": {
+          "example": "Research",
+          "type": "string"
+        },
+        "comments": {
+          "example": "Nil",
+          "type": "string"
+        },
+        "returnDate": {
+          "example": "12/7/2018 11:00:00 PM",
+          "type": "string"
+        },
+        "status": {
+          "example": "Accepted",
+          "type": "string"
+        },
+        "createdAt": {
+          "example": "6/24/2018 12:52:46 AM",
+          "type": "string"
+        },
+        "updatedAt": {
+          "example": "6/24/2018 1:06:38 AM",
+          "type": "string"
+        },
+        "userId": {
+          "example": 3,
+          "type": "integer",
+          "format": "int32"
+        },
+        "bookId": {
+          "example": 99,
+          "type": "integer",
+          "format": "int32"
+        },
+        "borrowRequests": {
+          "$ref": "#/definitions/BorrowRequests"
+        }
+      },
+      "required": [
+        "id",
+        "reason",
+        "comments",
+        "returnDate",
+        "status",
+        "createdAt",
+        "updatedAt",
+        "userId",
+        "bookId",
+        "borrowRequests"
+      ]
+    },
+    "BorrowRequests": {
+      "title": "BorrowRequests",
+      "example": {
+        "title": "Lies That Bind Us",
+        "author": "Andrew Hart"
+      },
+      "type": "object",
+      "properties": {
+        "title": {
+          "example": "Lies That Bind Us",
+          "type": "string"
+        },
+        "author": {
+          "example": "Andrew Hart",
+          "type": "string"
+        }
+      },
+      "required": [
+        "title",
+        "author"
+      ]
+    },
+    "UserReturnRequest": {
+      "title": "UserReturnRequest",
+      "example": {
+        "id": 4,
+        "comments": null,
+        "status": "Accepted",
+        "createdAt": "2018-06-24T01:14:32.115Z",
+        "updatedAt": "2018-06-24T01:20:19.244Z",
+        "userId": 3,
+        "bookId": 99,
+        "returnRequests": {
+          "title": "Lies That Bind Us",
+          "author": "Andrew Hart"
+        }
+      },
+      "type": "object",
+      "properties": {
+        "id": {
+          "example": 4,
+          "type": "integer",
+          "format": "int32"
+        },
+        "comments": {
+          "type": "string"
+        },
+        "status": {
+          "example": "Accepted",
+          "type": "string"
+        },
+        "createdAt": {
+          "example": "6/24/2018 1:14:32 AM",
+          "type": "string"
+        },
+        "updatedAt": {
+          "example": "6/24/2018 1:20:19 AM",
+          "type": "string"
+        },
+        "userId": {
+          "example": 3,
+          "type": "integer",
+          "format": "int32"
+        },
+        "bookId": {
+          "example": 99,
+          "type": "integer",
+          "format": "int32"
+        },
+        "returnRequests": {
+          "$ref": "#/definitions/ReturnRequests"
+        }
+      },
+      "required": [
+        "id",
+        "comments",
+        "status",
+        "createdAt",
+        "updatedAt",
+        "userId",
+        "bookId",
+        "returnRequests"
+      ]
+    },
+    "UserFavorite": {
+      "title": "UserFavorite",
+      "example": {
+        "id": 2,
+        "createdAt": "2018-06-23T19:14:10.907Z",
+        "updatedAt": "2018-06-23T19:14:10.907Z",
+        "userId": 3,
+        "bookId": 99,
+        "favBook": {
+          "title": "Lies That Bind Us",
+          "author": "Andrew Hart"
+        }
+      },
+      "type": "object",
+      "properties": {
+        "id": {
+          "example": 2,
+          "type": "integer",
+          "format": "int32"
+        },
+        "createdAt": {
+          "example": "6/23/2018 7:14:10 PM",
+          "type": "string"
+        },
+        "updatedAt": {
+          "example": "6/23/2018 7:14:10 PM",
+          "type": "string"
+        },
+        "userId": {
+          "example": 3,
+          "type": "integer",
+          "format": "int32"
+        },
+        "bookId": {
+          "example": 99,
+          "type": "integer",
+          "format": "int32"
+        },
+        "favBook": {
+          "$ref": "#/definitions/FavBook"
+        }
+      },
+      "required": [
+        "id",
+        "createdAt",
+        "updatedAt",
+        "userId",
+        "bookId",
+        "favBook"
+      ]
+    },
+    "FavBook": {
+      "title": "FavBook",
+      "example": {
+        "title": "Lies That Bind Us",
+        "author": "Andrew Hart"
+      },
+      "type": "object",
+      "properties": {
+        "title": {
+          "example": "Lies That Bind Us",
+          "type": "string"
+        },
+        "author": {
+          "example": "Andrew Hart",
+          "type": "string"
+        }
+      },
+      "required": [
+        "title",
+        "author"
+      ]
+    },
+    "GetAUser'sProfileerrorresponse": {
+      "title": "Get a user's profile ErrorResponse",
+      "example": {
+        "message": "Unsuccessful",
+        "error": "You are not authorized to perform this action"
+      },
+      "type": "object",
+      "properties": {
+        "message": {
+          "example": "Unsuccessful",
+          "type": "string"
+        },
+        "error": {
+          "example": "You are not authorized to perform this action",
+          "type": "string"
+        }
+      },
+      "required": [
+        "message",
+        "error"
+      ]
+    },
+    "GetAUser'sFavoriteBookserrorresponse": {
+      "title": "Get a user's favorite books ErrorResponse",
+      "example": {
+        "message": "Unsuccessful",
+        "error": "No token provided"
+      },
+      "type": "object",
+      "properties": {
+        "message": {
+          "example": "Unsuccessful",
+          "type": "string"
+        },
+        "error": {
+          "example": "You are not authorized to perform this action",
+          "type": "string"
+        }
+      },
+      "required": [
+        "message",
+        "error"
+      ]
+    },
+    "GetAUser'sFavoriteBooksresponse": {
+      "title": "Get a user's favorite books Response",
+      "example": {
+        "message": "Successful",
+        "favorites": [
+          {
+            "id": 2,
+            "createdAt": "2018-06-23T19:14:10.907Z",
+            "updatedAt": "2018-06-23T19:14:10.907Z",
+            "userId": 3,
+            "bookId": 99,
+            "favBook": {
+              "id": 99,
+              "title": "Lies That Bind Us",
+              "author": "Andrew Hart",
+              "description": "Jan needs this. She’s flying to Crete to reunite with friends she met there five years ago and relive an idyllic vacation. Basking in the warmth of the sun, the azure sea, and the aura of antiquity, she can once again pretend—for a little while—that she belongs. Her ex-boyfriend Marcus will be among them, but even he doesn’t know the secrets she keeps hidden behind a veil of lies. None of them really know her, and that’s only part of the problem.",
+              "subject": "Fiction",
+              "imageURL": "https://images-na.ssl-images-amazon.com/images/I/51SLlJ5SWOL.jpg",
+              "quantity": 10,
+              "borrowCount": 0,
+              "favCount": 1,
+              "upvotes": 0,
+              "downvotes": 1,
+              "createdAt": "2018-05-10T03:11:52.181Z",
+              "updatedAt": "2018-06-23T19:14:10.925Z"
+            }
+          }
+        ],
+        "pagination": {
+          "pageCount": 1,
+          "pageSize": 1,
+          "currentPage": 1,
+          "bookCount": 1
+        }
+      },
+      "type": "object",
+      "properties": {
+        "message": {
+          "example": "Successful",
+          "type": "string"
+        },
+        "favorites": {
+          "example": [
+            {
+              "id": 2,
+              "createdAt": "2018-06-23T19:14:10.907Z",
+              "updatedAt": "2018-06-23T19:14:10.907Z",
+              "userId": 3,
+              "bookId": 99,
+              "favBook": {
+                "id": 99,
+                "title": "Lies That Bind Us",
+                "author": "Andrew Hart",
+                "description": "Jan needs this. She’s flying to Crete to reunite with friends she met there five years ago and relive an idyllic vacation. Basking in the warmth of the sun, the azure sea, and the aura of antiquity, she can once again pretend—for a little while—that she belongs. Her ex-boyfriend Marcus will be among them, but even he doesn’t know the secrets she keeps hidden behind a veil of lies. None of them really know her, and that’s only part of the problem.",
+                "subject": "Fiction",
+                "imageURL": "https://images-na.ssl-images-amazon.com/images/I/51SLlJ5SWOL.jpg",
+                "quantity": 10,
+                "borrowCount": 0,
+                "favCount": 1,
+                "upvotes": 0,
+                "downvotes": 1,
+                "createdAt": "2018-05-10T03:11:52.181Z",
+                "updatedAt": "2018-06-23T19:14:10.925Z"
+              }
+            }
+          ],
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Favorite110"
+          }
+        },
+        "pagination": {
+          "$ref": "#/definitions/Pagination"
+        }
+      },
+      "required": [
+        "message",
+        "favorites",
+        "pagination"
+      ]
+    },
+    "Favorite110": {
+      "title": "Favorite110",
+      "example": {
+        "id": 2,
+        "createdAt": "2018-06-23T19:14:10.907Z",
+        "updatedAt": "2018-06-23T19:14:10.907Z",
+        "userId": 3,
+        "bookId": 99,
+        "favBook": {
+          "id": 99,
+          "title": "Lies That Bind Us",
+          "author": "Andrew Hart",
+          "description": "Jan needs this. She’s flying to Crete to reunite with friends she met there five years ago and relive an idyllic vacation. Basking in the warmth of the sun, the azure sea, and the aura of antiquity, she can once again pretend—for a little while—that she belongs. Her ex-boyfriend Marcus will be among them, but even he doesn’t know the secrets she keeps hidden behind a veil of lies. None of them really know her, and that’s only part of the problem.",
+          "subject": "Fiction",
+          "imageURL": "https://images-na.ssl-images-amazon.com/images/I/51SLlJ5SWOL.jpg",
+          "quantity": 10,
+          "borrowCount": 0,
+          "favCount": 1,
+          "upvotes": 0,
+          "downvotes": 1,
+          "createdAt": "2018-05-10T03:11:52.181Z",
+          "updatedAt": "2018-06-23T19:14:10.925Z"
+        }
+      },
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "",
+          "example": 2,
+          "type": "integer",
+          "format": "int32"
+        },
+        "createdAt": {
+          "description": "",
+          "example": "6/23/2018 7:14:10 PM",
+          "type": "string"
+        },
+        "updatedAt": {
+          "description": "",
+          "example": "6/23/2018 7:14:10 PM",
+          "type": "string"
+        },
+        "userId": {
+          "description": "",
+          "example": 3,
+          "type": "integer",
+          "format": "int32"
+        },
+        "bookId": {
+          "description": "",
+          "example": 99,
+          "type": "integer",
+          "format": "int32"
+        },
+        "favBook": {
+          "$ref": "#/definitions/FavBook111"
+        }
+      },
+      "required": [
+        "id",
+        "createdAt",
+        "updatedAt",
+        "userId",
+        "bookId",
+        "favBook"
+      ]
+    },
+    "FavBook111": {
+      "title": "FavBook111",
+      "example": {
+        "id": 99,
+        "title": "Lies That Bind Us",
+        "author": "Andrew Hart",
+        "description": "Jan needs this. She’s flying to Crete to reunite with friends she met there five years ago and relive an idyllic vacation. Basking in the warmth of the sun, the azure sea, and the aura of antiquity, she can once again pretend—for a little while—that she belongs. Her ex-boyfriend Marcus will be among them, but even he doesn’t know the secrets she keeps hidden behind a veil of lies. None of them really know her, and that’s only part of the problem.",
+        "subject": "Fiction",
+        "imageURL": "https://images-na.ssl-images-amazon.com/images/I/51SLlJ5SWOL.jpg",
+        "quantity": 10,
+        "borrowCount": 0,
+        "favCount": 1,
+        "upvotes": 0,
+        "downvotes": 1,
+        "createdAt": "2018-05-10T03:11:52.181Z",
+        "updatedAt": "2018-06-23T19:14:10.925Z"
+      },
+      "type": "object",
+      "properties": {
+        "id": {
+          "example": 99,
+          "type": "integer",
+          "format": "int32"
+        },
+        "title": {
+          "example": "Lies That Bind Us",
+          "type": "string"
+        },
+        "author": {
+          "example": "Andrew Hart",
+          "type": "string"
+        },
+        "description": {
+          "example": "Jan needs this. She’s flying to Crete to reunite with friends she met there five years ago and relive an idyllic vacation. Basking in the warmth of the sun, the azure sea, and the aura of antiquity, she can once again pretend—for a little while—that she belongs. Her ex-boyfriend Marcus will be among them, but even he doesn’t know the secrets she keeps hidden behind a veil of lies. None of them really know her, and that’s only part of the problem.",
+          "type": "string"
+        },
+        "subject": {
+          "example": "Fiction",
+          "type": "string"
+        },
+        "imageURL": {
+          "example": "https://images-na.ssl-images-amazon.com/images/I/51SLlJ5SWOL.jpg",
+          "type": "string"
+        },
+        "quantity": {
+          "example": 10,
+          "type": "integer",
+          "format": "int32"
+        },
+        "borrowCount": {
+          "example": 0,
+          "type": "integer",
+          "format": "int32"
+        },
+        "favCount": {
+          "example": 1,
+          "type": "integer",
+          "format": "int32"
+        },
+        "upvotes": {
+          "example": 0,
+          "type": "integer",
+          "format": "int32"
+        },
+        "downvotes": {
+          "example": 1,
+          "type": "integer",
+          "format": "int32"
+        },
+        "createdAt": {
+          "example": "5/10/2018 3:11:52 AM",
+          "type": "string"
+        },
+        "updatedAt": {
+          "example": "6/23/2018 7:14:10 PM",
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "title",
+        "author",
+        "description",
+        "subject",
+        "imageURL",
+        "quantity",
+        "borrowCount",
+        "favCount",
+        "upvotes",
+        "downvotes",
+        "createdAt",
+        "updatedAt"
+      ]
+    },
+    "ModifyABookresponse": {
+      "title": "Modify a book Response",
+      "example": {
+        "message": "Successful",
+        "updatedBook": {
+          "id": 99,
+          "title": "New title",
+          "author": "New author",
+          "description": "Jan needs this. She’s flying to Crete to reunite with friends she met there five years ago and relive an idyllic vacation. Basking in the warmth of the sun, the azure sea, and the aura of antiquity, she can once again pretend—for a little while—that she belongs. Her ex-boyfriend Marcus will be among them, but even he doesn’t know the secrets she keeps hidden behind a veil of lies. None of them really know her, and that’s only part of the problem.",
+          "subject": "Fiction",
+          "imageURL": "https://images-na.ssl-images-amazon.com/images/I/51SLlJ5SWOL.jpg",
+          "quantity": 10,
+          "borrowCount": 1,
+          "favCount": 1,
+          "upvotes": 0,
+          "downvotes": 1,
+          "createdAt": "2018-05-10T03:11:52.181Z",
+          "updatedAt": "2018-06-24T13:07:04.634Z"
+        }
+      },
+      "type": "object",
+      "properties": {
+        "message": {
+          "example": "Successful",
+          "type": "string"
+        },
+        "updatedBook": {
+          "$ref": "#/definitions/UpdatedBook"
+        }
+      },
+      "required": [
+        "message",
+        "updatedBook"
+      ]
+    },
+    "UpdatedBook": {
+      "title": "UpdatedBook",
+      "example": {
+        "id": 99,
+        "title": "New title",
+        "author": "New author",
+        "description": "Jan needs this. She’s flying to Crete to reunite with friends she met there five years ago and relive an idyllic vacation. Basking in the warmth of the sun, the azure sea, and the aura of antiquity, she can once again pretend—for a little while—that she belongs. Her ex-boyfriend Marcus will be among them, but even he doesn’t know the secrets she keeps hidden behind a veil of lies. None of them really know her, and that’s only part of the problem.",
+        "subject": "Fiction",
+        "imageURL": "https://images-na.ssl-images-amazon.com/images/I/51SLlJ5SWOL.jpg",
+        "quantity": 10,
+        "borrowCount": 1,
+        "favCount": 1,
+        "upvotes": 0,
+        "downvotes": 1,
+        "createdAt": "2018-05-10T03:11:52.181Z",
+        "updatedAt": "2018-06-24T13:07:04.634Z"
+      },
+      "type": "object",
+      "properties": {
+        "id": {
+          "example": 99,
+          "type": "integer",
+          "format": "int32"
+        },
+        "title": {
+          "example": "New title",
+          "type": "string"
+        },
+        "author": {
+          "example": "New author",
+          "type": "string"
+        },
+        "description": {
+          "example": "Jan needs this. She’s flying to Crete to reunite with friends she met there five years ago and relive an idyllic vacation. Basking in the warmth of the sun, the azure sea, and the aura of antiquity, she can once again pretend—for a little while—that she belongs. Her ex-boyfriend Marcus will be among them, but even he doesn’t know the secrets she keeps hidden behind a veil of lies. None of them really know her, and that’s only part of the problem.",
+          "type": "string"
+        },
+        "subject": {
+          "example": "Fiction",
+          "type": "string"
+        },
+        "imageURL": {
+          "example": "https://images-na.ssl-images-amazon.com/images/I/51SLlJ5SWOL.jpg",
+          "type": "string"
+        },
+        "quantity": {
+          "example": 10,
+          "type": "integer",
+          "format": "int32"
+        },
+        "borrowCount": {
+          "example": 1,
+          "type": "integer",
+          "format": "int32"
+        },
+        "favCount": {
+          "example": 1,
+          "type": "integer",
+          "format": "int32"
+        },
+        "upvotes": {
+          "example": 0,
+          "type": "integer",
+          "format": "int32"
+        },
+        "downvotes": {
+          "example": 1,
+          "type": "integer",
+          "format": "int32"
+        },
+        "createdAt": {
+          "example": "5/10/2018 3:11:52 AM",
+          "type": "string"
+        },
+        "updatedAt": {
+          "example": "6/24/2018 1:07:04 PM",
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "title",
+        "author",
+        "description",
+        "subject",
+        "imageURL",
+        "quantity",
+        "borrowCount",
+        "favCount",
+        "upvotes",
+        "downvotes",
+        "createdAt",
+        "updatedAt"
+      ]
+    },
+    "ModifyABookerrorresponse": {
+      "title": "Modify a book ErrorResponse",
+      "example": {
+        "message": "Unsuccessful",
+        "error": "ValidationError: child \"params\" fails because [child \"bookId\" fails because [\"bookId\" must be a positive number]]"
+      },
+      "type": "object",
+      "properties": {
+        "message": {
+          "example": "Unsuccessful",
+          "type": "string"
+        },
+        "error": {
+          "example": "ValidationError: child \"params\" fails because [child \"bookId\" fails because [\"bookId\" must be a positive number]]",
+          "type": "string"
+        }
+      },
+      "required": [
+        "message",
+        "error"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
#### What does this PR do?
Add swagger documentation for the API endpoints.

#### Description of Task to be completed?
- document requests and all error responses for the API endpoints
- set up swagger-ui-express to render the API documentation

#### How should this be manually tested?

Clone the repo and install application dependencies. Run command  `npm run start:server`. Navigate to the browser on ```127.0.0.1:3000/api/v1/docs```. You should see the API documentation.

#### Any background context you want to provide?

N/A

#### What are the relevant pivotal tracker stories?

#157879438

#### Screenshots (if appropriate)

N/A

#### Questions: N/A]